### PR TITLE
Remove the reference to N

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,243 @@
+name: Main
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  release:
+    types: [published]
+  schedule:
+    - cron: '30 20 * * *' # Warning: Timezone dep - 20:00 is 1:00
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubu22-gcc9-clang13
+            os: ubuntu-22.04
+            compiler: gcc-9
+            clang-runtime: '13'
+#          - name: ubu22-gcc9-clang14
+#            os: ubuntu-22.04
+#            compiler: gcc-9
+#            clang-runtime: '14'
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Save PR Info
+      run: |
+        mkdir -p ./pr
+        echo ${{ github.event.number }} > ./pr/NR
+        echo ${{ github.repository }} > ./pr/REPO
+        
+        export CLING_HASH=$(git ls-remote https://github.com/root-project/cling.git HEAD| tr '\t' '-')
+        # FIXME: We need something like cling-llvm to bump automatically...
+        export LLVM_HASH=$(git ls-remote https://github.com/root-project/llvm-project.git cling-llvm13 | tr '\t' '-')
+        echo "CLING_HASH=$CLING_HASH" >> $GITHUB_ENV
+        echo "LLVM_HASH=$LLVM_HASH" >> $GITHUB_ENV
+        
+    - uses: nelonoel/branch-name@v1.0.1
+    - name: Setup compiler on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+        vers="${compiler#*-}"
+        os_codename="`cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2`"
+        sudo apt update
+        if [[ "${{ matrix.compiler }}" == *"gcc"* ]]; then
+          sudo apt install -y gcc-${vers} g++-${vers} lld
+          echo "CC=gcc-${vers}" >> $GITHUB_ENV
+          echo "CXX=g++-${vers}" >> $GITHUB_ENV
+        else
+          if ! sudo apt install -y clang-${vers}; then
+            curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+            echo "deb https://apt.llvm.org/${os_codename}/ llvm-toolchain-${os_codename}-${vers} main" | sudo tee -a /etc/apt/sources.list
+            sudo apt update
+            sudo apt install -y clang-${vers}
+          fi
+          echo "CC=clang-${vers}" >> $GITHUB_ENV
+          echo "CXX=clang++-${vers}" >> $GITHUB_ENV
+        fi
+      env:
+        compiler: ${{ matrix.compiler }}
+    - name: Install deps on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # Install deps
+        sudo apt-get update
+        sudo apt-get install git g++ debhelper devscripts gnupg python3
+        conda install -y -q -c conda-forge \
+          distro \
+          pytest
+    - name: Restore Cache LLVM/Clang runtime build directory
+      uses: actions/cache/restore@v3
+      id: cache
+      with:
+        path: |
+          llvm-project/
+          cling/
+        #key: ...-.x-patch-${{ hashFiles('patches/llvm/*') }}
+        #key: ${{ env.CLING_HASH }}-${{ env.LLVM_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}.x
+        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}.x
+    - name: Build Cling on Linux if the cache is invalid
+      if: ${{ runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}
+      run: |
+        #if [[ "${{ steps.cling-build-cache.outputs.cache-hit }}" != "true" ]]; then
+        git clone --depth=1 https://github.com/root-project/cling.git
+        git clone --depth=1 -b cling-llvm13 https://github.com/root-project/llvm-project.git
+        cd llvm-project
+        mkdir build
+        cd build
+        cmake -DLLVM_ENABLE_PROJECTS=clang                  \
+              -DLLVM_EXTERNAL_PROJECTS=cling                \
+              -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../../cling  \
+              -DLLVM_TARGETS_TO_BUILD="host;NVPTX"          \
+              -DCMAKE_BUILD_TYPE=Release                    \
+              -DLLVM_ENABLE_ASSERTIONS=ON                   \
+              -DLLVM_USE_LINKER=lld                         \
+              -DCLANG_ENABLE_STATIC_ANALYZER=OFF            \
+              -DCLANG_ENABLE_ARCMT=OFF                      \
+              -DCLANG_ENABLE_FORMAT=OFF                     \
+              -DCLANG_ENABLE_BOOTSTRAP=OFF                  \
+              ../llvm
+        cmake --build . --target clang --parallel $(nproc --all)
+        cmake --build . --target cling --parallel $(nproc --all)
+        cmake --build . --target libcling --parallel $(nproc --all)
+        # Now build gtest.a and gtest_main for InterOp to run its tests.
+        cmake --build . --target gtest_main --parallel $(nproc --all)
+        cd ../../
+        #fi
+    - name: Save Cache LLVM/Clang runtime build directory
+      uses: actions/cache/save@v3
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      with:
+        path: |
+          llvm-project/
+          cling/
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+    - name: Build and Install InterOp on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # Build InterOp next to cling and llvm-project.
+        LLVM_DIR="$(realpath llvm-project)"
+        LLVM_BUILD_DIR="$(realpath llvm-project/build)"
+        CLING_DIR="$(realpath cling)"
+        CLING_BUILD_DIR="$(realpath cling/build)"
+        CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include"
+        git clone https://github.com/compiler-research/InterOp.git
+        cd InterOp
+        pwd
+        mkdir build install
+        export INTEROP_DIR="$(realpath install)"
+        cd build
+        cmake -DUSE_CLING=ON -DCling_DIR=$LLVM_BUILD_DIR -DCMAKE_INSTALL_PREFIX=$INTEROP_DIR ../
+        #cmake --build . --target check-interop --parallel $(nproc --all)
+        cmake --build . --target install --parallel $(nproc --all)
+        cd ../..
+        # We need INTEROP_DIR, LLVM_BUILD_DIR and CPLUS_INCLUDE_PATH later
+        echo "INTEROP_DIR=$INTEROP_DIR" >> $GITHUB_ENV
+        echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
+        echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
+    - name: Build and Install cppyy-backend on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # Install cppyy-backend
+        git clone https://github.com/compiler-research/cppyy-backend.git
+        cd cppyy-backend
+        mkdir python/cppyy_backend/lib build && cd build
+        cmake -DInterOp_DIR=$INTEROP_DIR ..
+        cmake --build . --parallel $(nproc --all)
+        cp libcppyy-backend.so ../python/cppyy_backend/lib/
+        cp $LLVM_BUILD_DIR/lib/libcling.so ../python/cppyy_backend/lib/
+        #
+        cd ../python
+        export CB_PYTHON_DIR=$PWD
+        cd ../..
+        # We need CB_PYTHON_DIR later
+        echo "CB_PYTHON_DIR=$CB_PYTHON_DIR" >> $GITHUB_ENV
+    - name: Install CPyCppyy on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # Setup virtual environment
+        python3 -m venv .venv
+        source .venv/bin/activate
+        # Install CPyCppyy
+        git clone https://github.com/compiler-research/CPyCppyy.git
+        cd CPyCppyy
+        mkdir build && cd build
+        cmake ..
+        cmake --build . --parallel $(nproc --all)
+        #
+        export CPYCPPYY_DIR=$PWD
+        cd ../..
+        # We need CPYCPPYY_DIR later
+        echo "CPYCPPYY_DIR=$CPYCPPYY_DIR" >> $GITHUB_ENV
+    - name: Install cppyy on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # source virtual environment
+        source .venv/bin/activate
+        # Install cppyy
+        python -m pip install --upgrade . --no-deps
+    - name: Run cppyy on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # Run cppyy
+        source .venv/bin/activate
+        export PYTHONPATH=$PYTHONPATH:$CPYCPPYY_DIR:$CB_PYTHON_DIR
+        python -c "import cppyy"
+        # We need PYTHONPATH later
+        echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
+    - name: Run the tests on Linux
+      continue-on-error: true
+      if: runner.os == 'Linux'
+      run: |
+        # Run the tests
+        source .venv/bin/activate
+        cd cppyy/test
+        make all || true
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        export PASSED=0
+        export NO_OF_TESTS=0
+        export SETUP_PLAN=$(python -m pytest --setup-plan | grep -o -P '(?<=test\/).*?(?=\ \(fixtures)')
+        echo ::group::Test Status
+        set +e
+        for test in ${SETUP_PLAN} ; do
+          NO_OF_TESTS=$((NO_OF_TESTS+1))
+          (
+            python -m pytest -s $test >> test.log 2>&1
+          )
+          if [[ $? -eq 0 ]]; then
+            PASSED=$((PASSED+1))
+            echo "$test PASSED"
+          else
+            echo "$test FAILED"
+          fi
+        done
+        set -e
+        echo ::endgroup::
+        echo "TEST SUMMARY: $PASSED out of $NO_OF_TESTS tests passed"
+        echo ::group::Test Logs
+        cat test.log
+        echo ::endgroup::
+        if [[ $PASSED -ne $NO_OF_TESTS ]]; then
+          exit 1
+        fi
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      # When debugging increase to a suitable value!

--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -228,14 +228,12 @@ def cppexec(stmt):
 def load_library(name):
     """Explicitly load a shared library."""
     with _stderr_capture() as err:
-        gSystem = gbl.gSystem
-        if name[:3] != 'lib':
-            if not gSystem.FindDynamicLibrary(gbl.CppyyLegacy.TString(name), True) and\
-                   gSystem.FindDynamicLibrary(gbl.CppyyLegacy.TString('lib'+name), True):
-                name = 'lib'+name
-        sc = gSystem.Load(name)
-    if sc == -1:
-        raise RuntimeError('Unable to load library "%s"%s' % (name, err.err))
+        InterOp = gbl.cling.InterOp
+        gCling = gbl.cling.runtime.gCling
+        result = InterOp.LoadLibrary(gCling, name)
+    if result == False:
+        raise RuntimeError('Could not load library "%s": %s' % (name, err.err))
+
     return True
 
 def include(header):

--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -182,7 +182,7 @@ del make_smartptr
 #--- interface to Cling ------------------------------------------------------
 class _stderr_capture(object):
     def __init__(self):
-       self._capture = not gbl.CppyyLegacy.gDebug and True or False
+       self._capture = False
        self.err = ""
 
     def __enter__(self):
@@ -198,8 +198,8 @@ def cppdef(src):
     """Declare C++ source <src> to Cling."""
     with _stderr_capture() as err:
         print(src)
-        errcode = gbl.cling.runtime.gCling.declare(src)
-    if not errcode:
+        errcode = gbl.cling.InterOp.Declare(gbl.cling.runtime.gCling, src)
+    if not errcode == 0:
         raise SyntaxError('Failed to parse the given C++ code%s' % err.err)
     return True
 
@@ -241,18 +241,18 @@ def load_library(name):
 def include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.cling.runtime.gCling.declare('#include "%s"' % header)
-    if not errcode:
+        errcode = gbl.cling.InterOp.Declare(gbl.cling.runtime.gCling, '#include "%s"' % header)
+    if not errcode == 0:
         raise ImportError('Failed to load header file "%s"%s' % (header, err.err))
     return True
 
 def c_include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.cling.runtime.gCling.declare("""extern "C" {
+        errcode = gbl.cling.InterOp.Declare(gbl.cling.runtime.gCling, """extern "C" {
 #include "%s"
 }""" % header)
-    if not errcode:
+    if not errcode == 0:
         raise ImportError('Failed to load header file "%s"%s' % (header, err.err))
     return True
 
@@ -260,7 +260,7 @@ def add_include_path(path):
     """Add a path to the include paths available to Cling."""
     if not os.path.isdir(path):
         raise OSError('No such directory: %s' % path)
-    gbl.cling.runtime.gCling.AddIncludePath(path)
+    gbl.cling.InterOp.AddIncludePath(gbl.cling.runtime.gCling, path)
 
 def add_library_path(path):
     """Add a path to the library search paths available to Cling."""

--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -197,6 +197,7 @@ class _stderr_capture(object):
 def cppdef(src):
     """Declare C++ source <src> to Cling."""
     with _stderr_capture() as err:
+        print(src)
         errcode = gbl.cling.runtime.gCling.declare(src)
     if not errcode:
         raise SyntaxError('Failed to parse the given C++ code%s' % err.err)

--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -86,7 +86,7 @@ sys.modules['cppyy.gbl.std'] = gbl.std
 
 
 #- enable auto-loading -------------------------------------------------------
-try:    gbl.gInterpreter.EnableAutoLoading()
+try:    gbl.cling.runtime.gCling.EnableAutoLoading()
 except: pass
 
 
@@ -197,7 +197,7 @@ class _stderr_capture(object):
 def cppdef(src):
     """Declare C++ source <src> to Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.gInterpreter.Declare(src)
+        errcode = gbl.cling.runtime.gCling.declare(src)
     if not errcode:
         raise SyntaxError('Failed to parse the given C++ code%s' % err.err)
     return True
@@ -212,7 +212,7 @@ def cppexec(stmt):
     with _stderr_capture() as err:
         errcode = ctypes.c_int(0)
         try:
-            gbl.gInterpreter.ProcessLine(stmt, ctypes.pointer(errcode))
+            gbl.cling.runtime.gCling.ProcessLine(stmt, ctypes.pointer(errcode))
         except Exception as e:
             sys.stderr.write("%s\n\n" % str(e))
             if not errcode.value: errcode.value = 1
@@ -240,7 +240,7 @@ def load_library(name):
 def include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.gInterpreter.Declare('#include "%s"' % header)
+        errcode = gbl.cling.runtime.gCling.declare('#include "%s"' % header)
     if not errcode:
         raise ImportError('Failed to load header file "%s"%s' % (header, err.err))
     return True
@@ -248,7 +248,7 @@ def include(header):
 def c_include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.gInterpreter.Declare("""extern "C" {
+        errcode = gbl.cling.runtime.gCling.declare("""extern "C" {
 #include "%s"
 }""" % header)
     if not errcode:
@@ -259,7 +259,7 @@ def add_include_path(path):
     """Add a path to the include paths available to Cling."""
     if not os.path.isdir(path):
         raise OSError('No such directory: %s' % path)
-    gbl.gInterpreter.AddIncludePath(path)
+    gbl.cling.runtime.gCling.AddIncludePath(path)
 
 def add_library_path(path):
     """Add a path to the library search paths available to Cling."""
@@ -356,7 +356,7 @@ def add_autoload_map(fname):
     """Add the entries from a autoload (.rootmap) file to Cling."""
     if not os.path.isfile(fname):
         raise OSError("no such file: %s" % fname)
-    gbl.gInterpreter.LoadLibraryMap(fname)
+    gbl.cling.runtime.gCling.LoadLibraryMap(fname)
 
 def set_debug(enable=True):
     """Enable/disable debug output."""
@@ -385,7 +385,7 @@ def sizeof(tt):
         try:
             sz = ctypes.sizeof(tt)
         except TypeError:
-            sz = gbl.gInterpreter.ProcessLine("sizeof(%s);" % (_get_name(tt),))
+            sz = gbl.cling.runtime.gCling.ProcessLine("sizeof(%s);" % (_get_name(tt),))
         _sizes[tt] = sz
         return sz
 
@@ -398,7 +398,7 @@ def typeid(tt):
         return _typeids[tt]
     except KeyError:
         tidname = 'typeid_'+str(len(_typeids))
-        gbl.gInterpreter.ProcessLine(
+        gbl.cling.runtime.gCling.ProcessLine(
             "namespace _cppyy_internal { auto* %s = &typeid(%s); }" %\
             (tidname, _get_name(tt),))
         tid = getattr(gbl._cppyy_internal, tidname)

--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -198,7 +198,7 @@ def cppdef(src):
     """Declare C++ source <src> to Cling."""
     with _stderr_capture() as err:
         print(src)
-        errcode = gbl.cling.InterOp.Declare(gbl.cling.runtime.gCling, src)
+        errcode = gbl.InterOp.Declare(gbl.cling.runtime.gCling, src)
     if not errcode == 0:
         raise SyntaxError('Failed to parse the given C++ code%s' % err.err)
     return True
@@ -228,7 +228,7 @@ def cppexec(stmt):
 def load_library(name):
     """Explicitly load a shared library."""
     with _stderr_capture() as err:
-        InterOp = gbl.cling.InterOp
+        InterOp = gbl.InterOp
         gCling = gbl.cling.runtime.gCling
         result = InterOp.LoadLibrary(gCling, name)
     if result == False:
@@ -239,7 +239,7 @@ def load_library(name):
 def include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.cling.InterOp.Declare(gbl.cling.runtime.gCling, '#include "%s"' % header)
+        errcode = gbl.InterOp.Declare(gbl.cling.runtime.gCling, '#include "%s"' % header)
     if not errcode == 0:
         raise ImportError('Failed to load header file "%s"%s' % (header, err.err))
     return True
@@ -247,7 +247,7 @@ def include(header):
 def c_include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.cling.InterOp.Declare(gbl.cling.runtime.gCling, """extern "C" {
+        errcode = gbl.InterOp.Declare(gbl.cling.runtime.gCling, """extern "C" {
 #include "%s"
 }""" % header)
     if not errcode == 0:
@@ -258,7 +258,7 @@ def add_include_path(path):
     """Add a path to the include paths available to Cling."""
     if not os.path.isdir(path):
         raise OSError('No such directory: %s' % path)
-    gbl.cling.InterOp.AddIncludePath(gbl.cling.runtime.gCling, path)
+    gbl.InterOp.AddIncludePath(gbl.cling.runtime.gCling, path)
 
 def add_library_path(path):
     """Add a path to the library search paths available to Cling."""

--- a/python/cppyy/__pyinstaller/hook-cppyy.py
+++ b/python/cppyy/__pyinstaller/hook-cppyy.py
@@ -21,7 +21,8 @@ def _backend_files():
 def _api_files():
     import cppyy, os
 
-    paths = str(cppyy.gbl.gInterpreter.GetIncludePath()).split('-I')
+    # FIXME: Need to use gCling.GetIncludePaths
+    paths = str(cppyy.gbl.runtime.gCling.GetIncludePath()).split('-I')
     for p in paths:
         if not p: continue
 

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -74,7 +74,7 @@ class Template(object):  # expected/used by ProxyWrappers.cxx in CPyCppyy
             args = args[0]
 
       # construct the type name from the types or their string representation
-        newargs = [self.__name__] if self.__name__ != "vector" else ["std::vector"]
+        newargs = [self.__scope__]
         for arg in args:
             if type(arg) == str:
                 arg = ','.join(map(lambda x: x.strip(), arg.split(',')))

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -73,7 +73,7 @@ class Template(object):  # expected/used by ProxyWrappers.cxx in CPyCppyy
             args = args[0]
 
       # construct the type name from the types or their string representation
-        newargs = [self.__name__]
+        newargs = [self.__name__] if self.__name__ != "vector" else ["std::vector"]
         for arg in args:
             if type(arg) == str:
                 arg = ','.join(map(lambda x: x.strip(), arg.split(',')))

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -146,26 +146,27 @@ gbl.std.move  = _backend.move
 #- add to the dynamic path as needed -----------------------------------------
 import os
 def add_default_paths():
-    gSystem = gbl.gSystem
+    libInterOp = gbl.cling.InterOp
+    gCling = gbl.cling.runtime.gCling
     if os.getenv('CONDA_PREFIX'):
       # MacOS, Linux
         lib_path = os.path.join(os.getenv('CONDA_PREFIX'), 'lib')
-        if os.path.exists(lib_path): gSystem.AddDynamicPath(lib_path)
+        if os.path.exists(lib_path): libInterOp.AddSearchPath(gCling, lib_path)
 
       # Windows
         lib_path = os.path.join(os.getenv('CONDA_PREFIX'), 'Library', 'lib')
-        if os.path.exists(lib_path): gSystem.AddDynamicPath(lib_path)
+        if os.path.exists(lib_path): libInterOp.AddSearchPath(gCling, lib_path)
 
   # assuming that we are in PREFIX/lib/python/site-packages/cppyy, add PREFIX/lib to the search path
     lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir))
-    if os.path.exists(lib_path): gSystem.AddDynamicPath(lib_path)
+    if os.path.exists(lib_path): libInterOp.AddSearchPath(gCling, lib_path)
 
     try:
         with open('/etc/ld.so.conf') as ldconf:
             for line in ldconf:
                 f = line.strip()
                 if (os.path.exists(f)):
-                    gSystem.AddDynamicPath(f)
+                    libInterOp.AddSearchPath(gCling, f)
     except IOError:
         pass
 add_default_paths()
@@ -179,7 +180,8 @@ nullptr       = _backend.nullptr
 default       = _backend.default
 
 def load_reflection_info(name):
-    sc = gbl.gSystem.Load(name)
+    gDLM = gbl.cling.runtime.gDLM
+    sc = gDLM.loadLibrary(name)
     if sc == -1:
         raise RuntimeError("Unable to load reflection library "+name)
 

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -146,7 +146,7 @@ gbl.std.move  = _backend.move
 #- add to the dynamic path as needed -----------------------------------------
 import os
 def add_default_paths():
-    libInterOp = gbl.cling.InterOp
+    libInterOp = gbl.InterOp
     gCling = gbl.cling.runtime.gCling
     if os.getenv('CONDA_PREFIX'):
       # MacOS, Linux

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -60,9 +60,10 @@ class Template(object):  # expected/used by ProxyWrappers.cxx in CPyCppyy
     stl_fixed_size_types = ['std::array']
     stl_mapping_types    = ['std::map']
 
-    def __init__(self, name):
+    def __init__(self, name, scope):
         self.__name__     = name
         self.__cpp_name__ = name
+        self.__scope__    = scope
 
     def __repr__(self):
         return "<cppyy.Template '%s' object at %s>" % (self.__name__, hex(id(self)))

--- a/setup.py
+++ b/setup.py
@@ -5,25 +5,26 @@ from distutils import log
 from setuptools.command.install import install as _install
 
 add_pkg = ['cppyy', 'cppyy.__pyinstaller']
-try:
-    import __pypy__, sys
-    version = sys.pypy_version_info
-    requirements = ['cppyy-backend==1.14.10', 'cppyy-cling==6.27.1']
-    if version[0] == 5:
-        if version[1] <= 9:
-            requirements = ['cppyy-backend<0.3', 'cppyy-cling<6.12']
-            add_pkg += ['cppyy_compat']
-        elif version[1] <= 10:
-            requirements = ['cppyy-backend<0.4', 'cppyy-cling<=6.15']
-    elif version[0] == 6:
-        if version[1] <= 0:
-            requirements = ['cppyy-backend<1.1', 'cppyy-cling<=6.15']
-    elif version[0] == 7:
-        if version[1] <= 3 and version[2] <= 3:
-            requirements = ['cppyy-backend<=1.10', 'cppyy-cling<=6.18.2.3']
-except ImportError:
-    # CPython
-    requirements = ['CPyCppyy==1.12.12', 'cppyy-backend==1.14.10', 'cppyy-cling==6.27.1']
+requirements = []
+#  try:
+#      import __pypy__, sys
+#      version = sys.pypy_version_info
+#      requirements = ['cppyy-backend==1.14.10', 'cppyy-cling==6.27.1']
+#      if version[0] == 5:
+#          if version[1] <= 9:
+#              requirements = ['cppyy-backend<0.3', 'cppyy-cling<6.12']
+#              add_pkg += ['cppyy_compat']
+#          elif version[1] <= 10:
+#              requirements = ['cppyy-backend<0.4', 'cppyy-cling<=6.15']
+#      elif version[0] == 6:
+#          if version[1] <= 0:
+#              requirements = ['cppyy-backend<1.1', 'cppyy-cling<=6.15']
+#      elif version[0] == 7:
+#          if version[1] <= 3 and version[2] <= 3:
+#              requirements = ['cppyy-backend<=1.10', 'cppyy-cling<=6.18.2.3']
+#  except ImportError:
+#      # CPython
+#      requirements = ['CPyCppyy==1.12.12', 'cppyy-backend==1.14.10', 'cppyy-cling==6.27.1']
 
 setup_requirements = ['wheel']
 if 'build' in sys.argv or 'install' in sys.argv:

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,19 +16,15 @@ dicts = advancedcppDict.so \
 
 all : $(dicts)
 
-genreflex_flags := $(shell genreflex --cppflags)
-cppflags=$(shell cling-config --cppflags) $(genreflex_flags) -O3 -fPIC -I$(shell python -c 'import sysconfig as sc; print(sc.get_config_var("INCLUDEPY"))') -Wno-register
+cppflags=$(shell cling-config --cppflags) -std=c++11 -O3 -fPIC -I$(shell python -c 'import sysconfig as sc; print(sc.get_config_var("INCLUDEPY"))') -Wno-register
 
 PLATFORM := $(shell uname -s)
 ifeq ($(PLATFORM),Darwin)
   cppflags+=-dynamiclib -single_module -undefined dynamic_lookup -Wno-delete-non-virtual-dtor
 endif
 
-%Dict.so: %_rflx.cpp %.cxx
+%Dict.so: %.cxx
 	$(CXX) $(cppflags) -shared -o $@ $^
-
-%_rflx.cpp: %.h %.xml
-	genreflex $< --selection=$*.xml --rootmap=$*Dict.rootmap --rootmap-lib=$*Dict.so
 
 .PHONY: test clean
 
@@ -36,4 +32,4 @@ test:
 	pytest test_*.py
 
 clean:
-	-rm -f $(dicts) $(subst .so,.rootmap,$(dicts)) $(subst Dict.so,_rflx_rdict.pcm,$(dicts)) $(subst Dict.so,_rflx.cpp,$(dicts)) $(wildcard *.pyc)
+	-rm -f $(dicts) $(wildcard *.pyc)

--- a/test/assert_interactive.py
+++ b/test/assert_interactive.py
@@ -14,4 +14,4 @@ try:
     assert g.std
 except ImportError:
  # full lazy lookup available
-    assert gInterpreter
+    assert cling.runtime.gCling

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,84 @@
+import py, os, sys
+from pytest import raises
+
+currpath = py.path.local(__file__).dirpath()
+test_dct = str(currpath.join("datatypesDict.so"))
+test_h = str(currpath.join("datatypes.h"))
+
+import cppyy
+
+cppyy.load_library(test_dct)
+cppyy.include(test_h)
+
+gbl = cppyy.gbl
+
+CppyyTestData = cppyy.gbl.CppyyTestData
+
+c = CppyyTestData()
+assert isinstance(c, CppyyTestData)
+
+# test that the enum is accessible as a type
+assert CppyyTestData.EWhat
+
+assert CppyyTestData.kNothing   ==   6
+assert CppyyTestData.kSomething == 111
+assert CppyyTestData.kLots      ==  42
+
+assert CppyyTestData.EWhat(CppyyTestData.kNothing) == CppyyTestData.kNothing
+assert CppyyTestData.EWhat(6) == CppyyTestData.kNothing
+# TODO: only allow instantiations with correct values (C++11)
+
+assert c.get_enum() == CppyyTestData.kNothing
+assert c.m_enum == CppyyTestData.kNothing
+
+c.m_enum = CppyyTestData.kSomething
+assert c.get_enum() == CppyyTestData.kSomething
+assert c.m_enum == CppyyTestData.kSomething
+
+c.set_enum(CppyyTestData.kLots)
+assert c.get_enum() == CppyyTestData.kLots
+assert c.m_enum == CppyyTestData.kLots
+
+assert c.s_enum == CppyyTestData.s_enum
+assert c.s_enum == CppyyTestData.kNothing
+assert CppyyTestData.s_enum == CppyyTestData.kNothing
+
+c.s_enum = CppyyTestData.kSomething
+assert c.s_enum == CppyyTestData.s_enum
+assert c.s_enum == CppyyTestData.kSomething
+assert CppyyTestData.s_enum == CppyyTestData.kSomething
+
+# global enums
+assert gbl.EFruit          # test type accessible
+assert gbl.kApple  == 78
+assert gbl.kBanana == 29
+assert gbl.kCitrus == 34
+assert gbl.EFruit.__name__     == 'EFruit'
+assert gbl.EFruit.__cpp_name__ == 'EFruit'
+
+assert gbl.EFruit.kApple  == 78
+assert gbl.EFruit.kBanana == 29
+assert gbl.EFruit.kCitrus == 34
+
+assert gbl.NamedClassEnum.E1 == 42
+assert gbl.NamedClassEnum.__name__     == 'NamedClassEnum'
+assert gbl.NamedClassEnum.__cpp_name__ == 'NamedClassEnum'
+
+assert gbl.EnumSpace.E
+assert gbl.EnumSpace.EnumClass.E1 == -1   # anonymous
+assert gbl.EnumSpace.EnumClass.E2 == -1   # named type
+
+assert gbl.EnumSpace.NamedClassEnum.E1 == -42
+assert gbl.EnumSpace.NamedClassEnum.__name__     == 'NamedClassEnum'
+assert gbl.EnumSpace.NamedClassEnum.__cpp_name__ == 'EnumSpace::NamedClassEnum'
+
+raises(TypeError, setattr, gbl.EFruit, 'kBanana', 42)
+
+assert gbl.g_enum == gbl.EFruit.kBanana
+gbl.g_enum = gbl.EFruit.kCitrus
+assert gbl.g_enum == gbl.EFruit.kCitrus
+
+# typedef enum
+assert gbl.EnumSpace.letter_code
+assert gbl.EnumSpace.AA == 1
+assert gbl.EnumSpace.BB == 2

--- a/test/test_advancedcpp.py
+++ b/test/test_advancedcpp.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong, IS_WINDOWS, ispypy
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("advancedcppDict"))
+test_dct = str(currpath.join("advancedcppDict.so"))
+test_h = str(currpath.join("advancedcpp.h"))
 
 def setup_module(mod):
     setup_make("advancedcpp")
@@ -13,8 +14,10 @@ def setup_module(mod):
 class TestADVANCEDCPP:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.advanced = cppyy.load_reflection_info(cls.test_dct)
+        cls.advanced = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_default_arguments(self):
         """Test usage of default arguments"""
@@ -159,7 +162,8 @@ class TestADVANCEDCPP:
         import cppyy
         gbl = cppyy.gbl
 
-        lib2 = cppyy.load_reflection_info("advancedcpp2Dict")
+        lib2 = cppyy.load_library("advancedcpp2")
+        lib2 = cppyy.include("advancedcpp2")
 
         assert gbl.a_ns      is gbl.a_ns
         assert gbl.a_ns.d_ns is gbl.a_ns.d_ns

--- a/test/test_concurrent.py
+++ b/test/test_concurrent.py
@@ -64,13 +64,13 @@ class TestCONCURRENT:
             bool _stopit = false; volatile bool* stopit = &_stopit;
         }""")
 
-        cppyy.gbl.gInterpreter.ProcessLine.__release_gil__ = True
+        cppyy.gbl.cling.runtime.gCling.process.__release_gil__ = True
         cmd = r"""\
            *test12_timeout::islive = true;
            while (!*test12_timeout::stopit);
         """
 
-        t = threading.Thread(target=cppyy.gbl.gInterpreter.ProcessLine, args=(cmd,))
+        t = threading.Thread(target=cppyy.gbl.cling.runtime.gCling.process, args=(cmd,))
         t.start()
 
       # have to give ProcessLine() time to actually start doing work

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("conversionsDict"))
+test_dct = str(currpath.join("conversionsDict.so"))
+test_h = str(currpath.join("conversions.h"))
 
 def setup_module(mod):
     setup_make("conversions")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestCONVERSIONS:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.conversion = cppyy.load_reflection_info(cls.test_dct)
+        cls.conversion = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_implicit_vector_conversions(self):
         """Test implicit conversions of std::vector"""

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -4,7 +4,8 @@ from .support import setup_make, ispypy
 
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("cpp11featuresDict"))
+test_dct = str(currpath.join("cpp11featuresDict.so"))
+test_h = str(currpath.join("cpp11features.h"))
 
 def setup_module(mod):
     setup_make("cpp11features")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestCPP11FEATURES:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.cpp11features = cppyy.load_reflection_info(cls.test_dct)
+        cls.cpp11features = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_smart_ptr(self):
         """Usage and access of std::shared/unique_ptr<>"""

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -304,7 +304,8 @@ class TestCPP11FEATURES:
         assert cppyy.gbl.gMyLambda(2)  == 42
         assert cppyy.gbl.gMyLambda(40) == 80
 
-        if cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") >= 201402:
+        # FIXME: Need to get the output of process somehow
+        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") >= 201402:
             cppyy.cppdef("auto gime_a_lambda1() { return []() { return 42; }; }")
             l1 = cppyy.gbl.gime_a_lambda1()
             assert l1
@@ -325,7 +326,8 @@ class TestCPP11FEATURES:
 
         import cppyy
 
-        if 201703 <= cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;"):
+        # FIXME: Need to get the output of process somehow
+        if 201703 <= cppyy.gbl.cling.runtime.gCling.process("__cplusplus;"):
             assert cppyy.gbl.std.optional
             assert cppyy.gbl.std.nullopt
 

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -1194,7 +1194,7 @@ class TestCROSSINHERITANCE:
 
         import cppyy
 
-        cppyy.gbl.gInterpreter.Declare("""\
+        cppyy.gbl.cling.runtime.gCling.Declare("""\
         namespace NonStandardOffset {
         struct Calc1 {
           virtual int calc1() = 0;

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -4,7 +4,8 @@ from .support import setup_make, pylong, IS_MAC_ARM
 
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("crossinheritanceDict"))
+test_dct = str(currpath.join("crossinheritanceDict.so"))
+test_h = str(currpath.join("crossinheritance.h"))
 
 def setup_module(mod):
     setup_make("crossinheritance")
@@ -13,8 +14,10 @@ def setup_module(mod):
 class TestCROSSINHERITANCE:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.example01 = cppyy.load_reflection_info(cls.test_dct)
+        cls.example01 = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_override_function(self):
         """Test ability to override a simple function"""

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -18,7 +18,7 @@ class TestDATATYPES:
         cls.datatypes = cppyy.load_library(cls.test_dct)
         cppyy.include(cls.test_h)
         cls.N = 5 #cppyy.gbl.N
-        at_least_17 = False #201402 < cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;")
+        at_least_17 = False #201402 < cppyy.gbl.cling.runtime.gCling.process("__cplusplus;")
         cls.has_byte     = at_least_17
         cls.has_optional = at_least_17
 

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong, pyunicode
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("datatypesDict"))
+test_dct = str(currpath.join("datatypesDict.so"))
+test_h = str(currpath.join("datatypes.h"))
 
 def setup_module(mod):
     setup_make("datatypes")
@@ -12,10 +13,12 @@ def setup_module(mod):
 class TestDATATYPES:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.N = cppyy.gbl.N
-        at_least_17 = 201402 < cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;")
+        cls.datatypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
+        cls.N = 5 #cppyy.gbl.N
+        at_least_17 = False #201402 < cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;")
         cls.has_byte     = at_least_17
         cls.has_optional = at_least_17
 

--- a/test/test_doc_features.py
+++ b/test/test_doc_features.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, ispypy, IS_WINDOWS
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("doc_helperDict"))
+test_dct = str(currpath.join("doc_helperDict.so"))
+test_h = str(currpath.join("doc_helper.h"))
 
 def setup_module(mod):
     setup_make("doc_helper")
@@ -12,12 +13,14 @@ def setup_module(mod):
 class TestDOCFEATURES:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
 
         # touch __version__ as a test
         assert hasattr(cppyy, '__version__')
 
-        cls.doc_helper = cppyy.load_reflection_info(cls.test_dct)
+        cls.doc_helper = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
         cppyy.cppdef("""
 #include <cmath>

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -627,7 +627,8 @@ class TestSIGNALS:
 class TestSTDNOTINGLOBAL:
     def setup_class(cls):
         import cppyy
-        cls.has_byte = 201402 < cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;")
+        # FIXME: Need to get the output of process somehow
+        cls.has_byte = 201402 < cppyy.gbl.cling.runtime.gCling.process("__cplusplus;")
 
     def test01_stl_in_std(self):
         """STL classes should live in std:: only"""

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("fragileDict"))
+test_dct = str(currpath.join("fragileDict.so"))
+test_h = str(currpath.join("fragile.h"))
 
 def setup_module(mod):
     setup_make("fragile")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestFRAGILE:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.fragile = cppyy.load_reflection_info(cls.test_dct)
+        cls.fragile = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_load_failure(self):
         """Test failure to load dictionary"""
@@ -567,8 +570,10 @@ class TestFRAGILE:
 class TestSIGNALS:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.fragile = cppyy.load_reflection_info(cls.test_dct)
+        cls.fragile = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_abortive_signals(self):
         """Conversion from abortive signals to Python exceptions"""

--- a/test/test_leakcheck.py
+++ b/test/test_leakcheck.py
@@ -3,7 +3,8 @@ from pytest import mark
 from .support import setup_make, pylong, pyunicode
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("datatypesDict"))
+test_dct = str(currpath.join("datatypesDict.so"))
+test_h = str(currpath.join("datatypes.h"))
 
 def setup_module(mod):
     setup_make("datatypes")
@@ -21,7 +22,9 @@ class TestLEAKCHECK:
         import cppyy, psutil
 
         cls.test_dct = test_dct
-        cls.memory = cppyy.load_reflection_info(cls.test_dct)
+        cls.test_h = test_h
+        cls.memory = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
         cls.process = psutil.Process(os.getpid())
 

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong, pyunicode, IS_WINDOWS, ispypy
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("datatypesDict"))
+test_dct = str(currpath.join("datatypesDict.so"))
+test_h = str(currpath.join("datatypes.h"))
 
 def setup_module(mod):
     setup_make("datatypes")
@@ -14,7 +15,9 @@ class TestLOWLEVEL:
         import cppyy
 
         cls.test_dct = test_dct
-        cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.test_h = test_h
+        cls.datatypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def test00_import_all(self):
@@ -508,7 +511,9 @@ class TestMULTIDIMARRAYS:
         import cppyy
 
         cls.test_dct = test_dct
-        cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.test_h = test_h
+        cls.datatypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.numeric_builtin_types = [
             'short', 'unsigned short', 'int', 'unsigned int', 'long', 'unsigned long',
             'long long', 'unsigned long long', 'float', 'double'

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong, maxvalue
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("operatorsDict"))
+test_dct = str(currpath.join("operatorsDict.so"))
+test_h = str(currpath.join("operators.h"))
 
 def setup_module(mod):
     setup_make("operators")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestOPERATORS:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.operators = cppyy.load_reflection_info(cls.test_dct)
+        cls.operators = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def teardown_method(self, meth):

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -17,7 +17,6 @@ class TestOPERATORS:
         import cppyy
         cls.operators = cppyy.load_library(cls.test_dct)
         cppyy.include(cls.test_h)
-        cls.N = cppyy.gbl.N
 
     def teardown_method(self, meth):
         import gc

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, ispypy, IS_WINDOWS
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("overloadsDict"))
+test_dct = str(currpath.join("overloadsDict.so"))
+test_h = str(currpath.join("overloads.h"))
 
 def setup_module(mod):
     setup_make("overloads")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestOVERLOADS:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.overloads = cppyy.load_reflection_info(cls.test_dct)
+        cls.overloads = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_class_based_overloads(self):
         """Test functions overloaded on different C++ clases"""

--- a/test/test_pythonify.py
+++ b/test/test_pythonify.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong, ispypy
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("example01Dict"))
+test_dct = str(currpath.join("example01Dict.so"))
+test_h = str(currpath.join("example01.h"))
 
 def setup_module(mod):
     setup_make("example01")
@@ -12,14 +13,17 @@ def setup_module(mod):
 class TestPYTHONIFY:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.example01 = cppyy.load_reflection_info(cls.test_dct)
+        cls.example01 = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_load_dictionary_cache(self):
         """Test whether loading a dictionary twice results in the same object"""
 
         import cppyy
-        lib2 = cppyy.load_reflection_info(self.test_dct)
+        lib2 = cppyy.load_library(self.test_dct)
+        cppyy.include(self.test_h)
         assert self.example01 is lib2
 
     def test02_finding_classes(self):
@@ -537,8 +541,10 @@ class TestPYTHONIFY:
 class TestPYTHONIFY_UI:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h
         import cppyy
-        cls.example01 = cppyy.load_reflection_info(cls.test_dct)
+        cls.example01 = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_pythonizations(self):
         """Test addition of user-defined pythonizations"""

--- a/test/test_pythonization.py
+++ b/test/test_pythonization.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("pythonizablesDict"))
+test_dct = str(currpath.join("pythonizablesDict.so"))
+test_h = str(currpath.join("pythonizables.h"))
 
 def setup_module(mod):
     setup_make("pythonizables")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestClassPYTHONIZATION:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.pyzables = cppyy.load_reflection_info(cls.test_dct)
+        cls.pyzables = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test00_api(self):
         """Test basic semantics of the pythonization API"""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -52,11 +52,11 @@ class TestREGRESSION:
 
         import cppyy, pydoc
 
-        assert not '__abstractmethods__' in dir(cppyy.gbl.gInterpreter)
-        assert '__class__' in dir(cppyy.gbl.gInterpreter)
+        assert not '__abstractmethods__' in dir(cppyy.gbl.cling.runtime.gCling)
+        assert '__class__' in dir(cppyy.gbl.cling.runtime.gCling)
 
         self.__class__.helpout = []
-        pydoc.doc(cppyy.gbl.gInterpreter)
+        pydoc.doc(cppyy.gbl.cling.runtime.gCling)
         helptext = ''.join(self.__class__.helpout)
         assert 'TInterpreter' in helptext
         assert 'CPPInstance' in helptext
@@ -1006,7 +1006,7 @@ class TestREGRESSION:
 
         import cppyy
 
-        if cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") > 201402:
+        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") > 201402:
             cppyy.cppdef("""\
             #include <filesystem>
             std::string stack_std_path() {

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -1566,7 +1566,8 @@ class TestSTLSTRING_VIEW:
         """Usage of std::string_view as formal argument"""
 
         import cppyy
-        if cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") <= 201402:
+        # FIXME: Need to get the output of process somehow
+        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") <= 201402:
             # string_view exists as of C++17
             return
         countit = cppyy.gbl.StringViewTest.count

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -4,7 +4,8 @@ from pytest import raises
 from .support import setup_make, pylong, pyunicode, maxvalue, ispypy
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("stltypesDict"))
+test_dct = str(currpath.join("stltypesDict.so"))
+test_h = str(currpath.join("stltypes.h"))
 
 def setup_module(mod):
     setup_make("stltypes")
@@ -195,8 +196,10 @@ def getslice_cpython_test(type2test):
 class TestSTLVECTOR:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def test01_builtin_type_vector_types(self):
@@ -695,8 +698,10 @@ class TestSTLVECTOR:
 class TestSTLSTRING:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_string_argument_passing(self):
         """Test mapping of python strings and std::[w]string"""
@@ -991,8 +996,10 @@ class TestSTLSTRING:
 class TestSTLLIST:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = 13
 
     def test01_builtin_list_type(self):
@@ -1107,8 +1114,10 @@ class TestSTLLIST:
 class TestSTLMAP:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = 13
 
     def test01_builtin_map_type(self):
@@ -1423,8 +1432,10 @@ class TestSTLMAP:
 class TestSTLITERATOR:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_builtin_vector_iterators(self):
         """Test iterator comparison with operator== reflected"""
@@ -1457,8 +1468,10 @@ class TestSTLITERATOR:
 class TestSTLARRAY:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_array_of_basic_types(self):
         """Usage of std::array of basic types"""
@@ -1544,8 +1557,10 @@ class TestSTLARRAY:
 class TestSTLSTRING_VIEW:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_string_through_string_view(self):
         """Usage of std::string_view as formal argument"""
@@ -1608,8 +1623,10 @@ class TestSTLSTRING_VIEW:
 class TestSTLDEQUE:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def test01_deque_byvalue_regression(self):
@@ -1635,8 +1652,10 @@ class TestSTLDEQUE:
 class TestSTLSET:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def test01_set_iteration(self):
@@ -1728,8 +1747,10 @@ class TestSTLSET:
 class TestSTLTUPLE:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def test01_tuple_creation_and_access(self):
@@ -1818,8 +1839,10 @@ class TestSTLTUPLE:
 class TestSTLPAIR:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
         cls.N = cppyy.gbl.N
 
     def test01_pair_pack_unpack(self):
@@ -1838,8 +1861,10 @@ class TestSTLPAIR:
 class TestSTLEXCEPTION:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
+        cls.stltypes = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_basics(self):
         """Test behavior of std::exception derived classes"""

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("std_streamsDict"))
+test_dct = str(currpath.join("std_streamsDict.so"))
+test_h = str(currpath.join("std_streams.h"))
 
 def setup_module(mod):
     setup_make("std_streams")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestSTDStreams:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.streams = cppyy.load_reflection_info(cls.test_dct)
+        cls.streams = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_std_ostream(self):
         """Test availability of std::ostream"""

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -3,7 +3,8 @@ from pytest import raises
 from .support import setup_make, pylong
 
 currpath = py.path.local(__file__).dirpath()
-test_dct = str(currpath.join("templatesDict"))
+test_dct = str(currpath.join("templatesDict.so"))
+test_h = str(currpath.join("templates.h"))
 
 def setup_module(mod):
     setup_make("templates")
@@ -12,8 +13,10 @@ def setup_module(mod):
 class TestTEMPLATES:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.templates = cppyy.load_reflection_info(cls.test_dct)
+        cls.templates = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test00_template_back_reference(self):
         """Template reflection"""
@@ -1129,8 +1132,10 @@ class TestTEMPLATES:
 class TestTEMPLATED_TYPEDEFS:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.templates = cppyy.load_reflection_info(cls.test_dct)
+        cls.templates = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_using(self):
         """Test presence and validity of using typedefs"""
@@ -1242,8 +1247,10 @@ class TestTEMPLATED_TYPEDEFS:
 class TestTEMPLATE_TYPE_REDUCTION:
     def setup_class(cls):
         cls.test_dct = test_dct
+        cls.test_h = test_h
         import cppyy
-        cls.templates = cppyy.load_reflection_info(cls.test_dct)
+        cls.templates = cppyy.load_library(cls.test_dct)
+        cppyy.include(cls.test_h)
 
     def test01_reduce_binary(self):
         """Squash template expressions for binary operations (like in gmpxx)"""

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -296,7 +296,8 @@ class TestTEMPLATES:
         assert iavec[5] == 5
 
       # with variadic template
-        if cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") > 201402:
+        # FIXME: Need to get the output of process somehow
+        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") > 201402:
             assert nsup.matryoshka[int, 3].type
             assert nsup.matryoshka[int, 3, 4].type
             assert nsup.make_vector[int , 3]
@@ -304,7 +305,8 @@ class TestTEMPLATES:
             assert nsup.make_vector[int , 4]().m_val == 4
 
       # with inner types using
-        assert cppyy.gbl.gInterpreter.CheckClassTemplate("using_problem::Bar::Foo")
+        # FIXME: Need to get the output of process somehow
+        assert cppyy.gbl.cling.runtime.gCling.CheckClassTemplate("using_problem::Bar::Foo")
         assert nsup.Foo
         assert nsup.Bar.Foo       # used to fail
 


### PR DESCRIPTION
The operator tests reference `N` in their setup but it is not used anywhere. It is also the current source of failure for these tests.