### PR TITLE
Modify test to remove calls to old interface

### DIFF
--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -49,28 +49,18 @@ class TestSTDStreams:
         cppyy.gbl.stringstream_base.pass_through_base(s)
         assert s.str() == "TEST STRING"
 
-    @mark.xfail
     def test04_naming_of_ostringstream(self):
         """Naming consistency of ostringstream"""
 
         import cppyy
 
-        short_type = cppyy.gbl.CppyyLegacy.TClassEdit.ShortType
-        s0 = short_type("std::basic_ostringstream<char>", 2)
-        s1 = short_type("std::basic_ostringstream<char, std::char_traits<char> >", 2)
-        s2 = short_type("std::basic_ostringstream<char,struct std::char_traits<char> >", 2)
-        s3 = short_type("std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >", 2)
-        s4 = short_type("std::basic_ostringstream<char,struct std::char_traits<char>, std::allocator<char> >", 2)
+        # No equivalent of ShortType in Cling
 
-        assert s1 == s0
-        assert s2 == s0
-        assert s3 == s0
-        assert s4 == s0
+        # Instead of checking if GetClass returns the same class check if the object created is equivalent
 
-        get_class = cppyy.gbl.CppyyLegacy.TClass.GetClass
-        cl0 = get_class("std::ostringstream")
-        cl1 = get_class("std::basic_ostringstream<char>")
-        cl2 = get_class("std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >")
+        cl0 = cppyy.gbl.std.ostringstream
+        cl1 = cppyy.gbl.std.basic_ostringstream['char']
+        cl1 = cppyy.gbl.std.basic_ostringstream['char', cppyy.gbl.std.char_traits['char'] , cppyy.gbl.std.allocator['char']]
 
         assert cl0 == cl1
         assert cl1 == cl2


### PR DESCRIPTION
This test, `test04_naming_of_ostringstream`, was used to compare the output of ShortType and GetClass for different strings that refer to the same class. As we no longer use these interfaces, one way to test these can be though the proxies created by cppyy.

RFC: @wlav 