### PR TITLE
Rely on InterOp::Evaluate for expression evaluation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
 
         echo "Crashing Summary: \n"
         tail -n1 test_crashed.log
+        echo "Progress id Summary:"
+        # We sum all of the failing tests line number, the greater the sum the
+        # closer towards the end of the test cases we are.
+        cat --number test_xfailed.log | grep '> ' | sed 's@^[^0-9]*\([0-9]\+\).*@\1@' | paste -s -d+ | bc
         echo "XFAIL Summary:"
         tail -n1 test_xfailed.log
         echo "OF TOTAL $(python3 -m pytest  --collect-only -q | tail -n1)"

--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -210,7 +210,7 @@ def cppexec(stmt):
     if stmt and stmt[-1] != ';':
         stmt += ';'
 
-  # capture stderr, but note that ProcessLine could legitimately be writing to
+  # capture stderr, but note that Process could legitimately be writing to
   # std::cerr, in which case the captured output needs to be printed as normal
     with _stderr_capture() as err:
         errcode = ctypes.c_int(0)
@@ -383,7 +383,7 @@ def sizeof(tt):
         try:
             sz = ctypes.sizeof(tt)
         except TypeError:
-            sz = gbl.cling.runtime.gCling.ProcessLine("sizeof(%s);" % (_get_name(tt),))
+            sz = gbl.InterOp.Evaluate(gbl.cling.runtime.gCling, "sizeof(%s);" % (_get_name(tt),))
         _sizes[tt] = sz
         return sz
 
@@ -396,7 +396,7 @@ def typeid(tt):
         return _typeids[tt]
     except KeyError:
         tidname = 'typeid_'+str(len(_typeids))
-        gbl.cling.runtime.gCling.ProcessLine(
+        cppexec(
             "namespace _cppyy_internal { auto* %s = &typeid(%s); }" %\
             (tidname, _get_name(tt),))
         tid = getattr(gbl._cppyy_internal, tidname)

--- a/test/test_advancedcpp.py
+++ b/test/test_advancedcpp.py
@@ -915,7 +915,6 @@ class TestADVANCEDCPP:
 
         assert ns.deeper.some_other_func_xc() == 42
 
-    @mark.xfail
     def test29_castcpp(self):
         """Allow casting a Python class to a C++ one"""
 

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -323,8 +323,7 @@ class TestCPP11FEATURES:
         assert cppyy.gbl.gMyLambda(2)  == 42
         assert cppyy.gbl.gMyLambda(40) == 80
 
-        # FIXME: Need to get the output of process somehow
-        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") >= 201402:
+        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") >= 201402:
             cppyy.cppdef("auto gime_a_lambda1() { return []() { return 42; }; }")
             l1 = cppyy.gbl.gime_a_lambda1()
             assert l1
@@ -345,8 +344,7 @@ class TestCPP11FEATURES:
 
         import cppyy
 
-        # FIXME: Need to get the output of process somehow
-        if 201703 <= cppyy.gbl.cling.runtime.gCling.process("__cplusplus;"):
+        if 201703 <= cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;"):
             assert cppyy.gbl.std.optional
             assert cppyy.gbl.std.nullopt
 

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -1202,13 +1202,12 @@ class TestCROSSINHERITANCE:
             with raises(TypeError):
                 PyDerived()
 
-    @mark.xfail
     def test27_interfaces(self):
         """Inherit from base with non-standard offset"""
 
         import cppyy
 
-        cppyy.gbl.cling.runtime.gCling.Declare("""\
+        cppyy.gbl.InterOp.Declare(cppyy.gbl.cling.runtime.gCling, """\
         namespace NonStandardOffset {
         struct Calc1 {
           virtual int calc1() = 0;

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -15,7 +15,7 @@ class TestDATATYPES:
         import cppyy
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = 5 #cppyy.gbl.N
-        at_least_17 = False #201402 < cppyy.gbl.cling.runtime.gCling.process("__cplusplus;")
+        at_least_17 = 201402 < cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;")
         cls.has_byte     = at_least_17
         cls.has_optional = at_least_17
 
@@ -1700,7 +1700,6 @@ class TestDATATYPES:
 
         assert 'foo' in dir(ns.libuntitled1_ExportedSymbols().kotlin.root.com.justamouse.kmmdemo)
 
-    @mark.xfail
     def test33_pointer_to_array(self):
         """Usability of pointer to array"""
 

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -2022,6 +2022,7 @@ class TestDATATYPES:
         assert b.name     == "aap"
         assert b.buf_type == ns.SHAPE
 
+    @mark.xfail
     def test40_more_aggregates(self):
         """More aggregate testings (used to fail/report errors)"""
 

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -668,8 +668,7 @@ class TestSIGNALS:
 class TestSTDNOTINGLOBAL:
     def setup_class(cls):
         import cppyy
-        # FIXME: Need to get the output of process somehow
-        cls.has_byte = 201402 < cppyy.gbl.cling.runtime.gCling.process("__cplusplus;")
+        cls.has_byte = 201402 < cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;")
 
     def test01_stl_in_std(self):
         """STL classes should live in std:: only"""

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -476,7 +476,7 @@ class TestFRAGILE:
         assert not 'ESysConstants' in dd
         assert not 'kDoRed' in dd
 
-    @mark.xfail
+    @mark.crashes
     def test20_capture_output(self):
         """Capture cerr into a string"""
 

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -323,7 +323,6 @@ class TestLOWLEVEL:
             for meth in meth_types:
                 with raises(TypeError): getattr(ctd, 'set_'+meth+ext)(i)
 
-    @mark.xfail
     def test09_numpy_bool_array(self):
         """Test passing of numpy bool array"""
 
@@ -440,7 +439,6 @@ class TestLOWLEVEL:
         assert not ns.gime_null()
         assert list(ns.gime_null()) == []
 
-    @mark.xfail
     def test13_array_interface(self):
         """Test usage of __array__ from numpy"""
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1029,7 +1029,7 @@ class TestREGRESSION:
 
         import cppyy
 
-        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") > 201402:
+        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") > 201402:
             cppyy.cppdef("""\
             #include <filesystem>
             std::string stack_std_path() {

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -1604,12 +1604,12 @@ class TestSTLSTRING_VIEW:
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
 
+    @mark.xfail
     def test01_string_through_string_view(self):
         """Usage of std::string_view as formal argument"""
 
         import cppyy
-        # FIXME: Need to get the output of process somehow
-        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") <= 201402:
+        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") <= 201402:
             # string_view exists as of C++17
             return
         countit = cppyy.gbl.StringViewTest.count

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -32,7 +32,7 @@ class TestSTDStreams:
 
         assert not (cppyy.gbl.std.cout is None)
 
-    @mark.xfail
+    @mark.crashes
     def test03_consistent_naming_if_char_traits(self):
         """Naming consistency if char_traits"""
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -305,8 +305,7 @@ class TestTEMPLATES:
         assert iavec[5] == 5
 
       # with variadic template
-        # FIXME: Need to get the output of process somehow
-        if cppyy.gbl.cling.runtime.gCling.process("__cplusplus;") > 201402:
+        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") > 201402:
             assert nsup.matryoshka[int, 3].type
             assert nsup.matryoshka[int, 3, 4].type
             assert nsup.make_vector[int , 3]
@@ -314,8 +313,7 @@ class TestTEMPLATES:
             assert nsup.make_vector[int , 4]().m_val == 4
 
       # with inner types using
-        # FIXME: Need to get the output of process somehow
-        assert cppyy.gbl.cling.runtime.gCling.CheckClassTemplate("using_problem::Bar::Foo")
+        assert cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "using_problem::Bar::Foo")
         assert nsup.Foo
         assert nsup.Bar.Foo       # used to fail
 


### PR DESCRIPTION
This change follows compiler-research/InterOp@2774f67.