### PR TITLE
Annotate the crashing tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,19 +208,33 @@ jobs:
         # Run the tests
         source .venv/bin/activate
         cd test
-        make all || true
+        echo ::group::Prepare For Testing
+        make all
         python -m pip install --upgrade pip
         python -m pip install pytest
         python -m pip install pytest-xdist
-        echo ::group::Test Logs
-        python -m pytest -n 1 -sv --max-worker-restart 512 | tee test.log 2>&1
-        export PYTEST_RETCODE="${PIPESTATUS[0]}"
         echo ::endgroup::
-        echo "TEST SUMMARY: \n"
-        tail -n1 test.log
+
+        echo ::group::Crashing Test Logs
+        # See if we don't have a crash that went away
+        python -m pytest -n 1 -m "crashes" -sv --max-worker-restart 512 | tee test_crashed.log 2>&1
+        echo ::endgroup::
+
+        echo ::group::XFAIL Test Logs
+        # See if we don't have an xfail that went away
+        python -m pytest -m "not crashes" --runxfail -s  | tee test_xfailed.log 2>&1
+        echo ::endgroup::
+
+        # Run the rest of the non-crashing tests.
+        python -m pytest -m "not crashes" -v
+        export PYTEST_RETCODE=$?
+
+        echo "Crashing Summary: \n"
+        tail -n1 test_crashed.log
+        echo "XFAIL Summary:"
+        tail -n1 test_xfailed.log
         echo "OF TOTAL $(python3 -m pytest  --collect-only -q | tail -n1)"
         echo "Return Code: ${PYTEST_RETCODE}"
-        tail -n1 test.log | grep -q "xpassed" ; test $? -eq 1
         exit $PYTEST_RETCODE
     - name: Setup tmate session
       if: ${{ failure() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,7 @@
 requires = ["setuptools", "wheel"]
 backend-path = ["installer"]
 build-backend = "cppyy_monkey_patch:main"
+[tool.pytest.ini_options]
+markers = [
+    "crashes: marks tests as crashing (deselect with '-m \"not crashes\"')",
+]

--- a/test/test_advancedcpp.py
+++ b/test/test_advancedcpp.py
@@ -183,7 +183,7 @@ class TestADVANCEDCPP:
         assert gbl.a_ns.d_ns.i_class.j_class.s_j      == 333
         assert gbl.a_ns.d_ns.i_class.j_class().m_j    == -10
 
-    @mark.xfail
+    @mark.crashes
     def test04_template_types(self):
         """Test bindings of templated types"""
 
@@ -786,7 +786,7 @@ class TestADVANCEDCPP:
         assert d2.vcheck()  == 'A'
         assert d2.vcheck(1) == 'B'
 
-    @mark.xfail
+    @mark.crashes
     def test24_typedef_to_private_class(self):
         """Typedefs to private classes should not resolve"""
 
@@ -794,7 +794,7 @@ class TestADVANCEDCPP:
 
         assert cppyy.gbl.TypedefToPrivateClass().f().m_val == 42
 
-    @mark.xfail
+    @mark.crashes
     def test25_ostream_printing(self):
         """Mapping of __str__ through operator<<(ostream&)"""
 
@@ -893,7 +893,7 @@ class TestADVANCEDCPP:
         #assert type(ns.A.Val(1)) == int
         #assert type(ns.B.Val(1)) == float
 
-    @mark.xfail
+    @mark.crashes
     def test28_extern_C_in_namespace(self):
         """Access to extern "C" declared functions in namespaces"""
 
@@ -915,6 +915,7 @@ class TestADVANCEDCPP:
 
         assert ns.deeper.some_other_func_xc() == 42
 
+    @mark.xfail
     def test29_castcpp(self):
         """Allow casting a Python class to a C++ one"""
 

--- a/test/test_concurrent.py
+++ b/test/test_concurrent.py
@@ -17,6 +17,7 @@ class TestCONCURRENT:
 
         cppyy.gbl.Workers.calc.__release_gil__ = True
 
+    @mark.crashes
     def test01_simple_threads(self):
         """Run basic Python threads"""
 
@@ -35,6 +36,7 @@ class TestCONCURRENT:
         for t in threads:
             t.join()
 
+    @mark.crashes
     def test02_futures(self):
         """Run with Python futures"""
 
@@ -256,6 +258,7 @@ class TestCONCURRENT:
         for t in threads:
             t.join()
 
+    @mark.crashes
     def test07_overload_reuse_in_threads_wo_gil(self):
         """Threads reuse overload objects; check for clashes if no GIL"""
 

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -15,7 +15,7 @@ class TestCONVERSIONS:
         import cppyy
         cls.conversion = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail
+    @mark.crashes
     def test01_implicit_vector_conversions(self):
         """Test implicit conversions of std::vector"""
 

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -311,7 +311,7 @@ class TestCPP11FEATURES:
         for l in (['x'], ['x', 'y', 'z']):
             assert ns.foo(l) == std.vector['std::string'](l)
 
-    @mark.xfail
+    @mark.crashes
     def test09_lambda_calls(self):
         """Call (global) lambdas"""
 
@@ -372,6 +372,7 @@ class TestCPP11FEATURES:
         # following used to fail with compilation error
         t = std.chrono.system_clock.now() + std.chrono.seconds(1)
 
+    @mark.crashes
     def test12_stdfunction(self):
         """Use of std::function with arguments in a namespace"""
 

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -206,6 +206,7 @@ class TestCROSSINHERITANCE:
         assert CX.IBase4.call_get_value(c1) == 17
         assert CX.IBase4.call_get_value(c2) == 27
 
+    @mark.xfail
     def test07_templated_base(self):
         """Derive from a base class that is instantiated from a template"""
 
@@ -336,7 +337,7 @@ class TestCROSSINHERITANCE:
         gc.collect()
         assert CB.s_count == 0 + start_count
 
-    @mark.xfail
+    @mark.crashes
     def test11_python_in_make_shared(self):
         """Usage of Python derived objects with std::make_shared"""
 
@@ -401,7 +402,7 @@ class TestCROSSINHERITANCE:
         gc.collect()
         assert CB.s_count == 0 + start_count
 
-    @mark.xfail
+    @mark.crashes
     def test12_python_shared_ptr_memory(self):
         """Usage of Python derived objects with std::shared_ptr"""
 

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1109,7 +1109,7 @@ class TestDATATYPES:
 
         assert not d2
 
-    @mark.xfail
+    @mark.crashes
     def test22_buffer_shapes(self):
         """Correctness of declared buffer shapes"""
 
@@ -1522,7 +1522,7 @@ class TestDATATYPES:
         d.execute = d.xyz
         assert d.do_execute() == "xyz"
 
-    @mark.xfail
+    @mark.crashes
     def test30_multi_dim_arrays_of_builtins(test):
         """Multi-dim arrays of builtins"""
 
@@ -2060,7 +2060,7 @@ class TestDATATYPES:
             r2 = ns.make_R2()
             assert r2.s.x == 1
 
-    @mark.xfail
+    @mark.crashes
     def test41_complex_numpy_arrays(self):
         """Usage of complex numpy arrays"""
 

--- a/test/test_doc_features.py
+++ b/test/test_doc_features.py
@@ -851,7 +851,7 @@ class TestADVERTISED:
         assert list(arr) == [1, 42, 1, 42]
         cppyy.gbl.free(vp)
 
-    @mark.xfail
+    @mark.crashes
     def test04_ptr_ptr_python_owns(self):
         """Example of ptr-ptr use where python owns"""
 
@@ -888,6 +888,7 @@ class TestADVERTISED:
         cppyy.gbl.Advert04.ptr2ptr_init(s)
         assert s.i == 42
 
+    @mark.crashes
     def test05_ptr_ptr_with_array(self):
         """Example of ptr-ptr with array"""
 

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -369,6 +369,7 @@ class TestFRAGILE:
         l = k.GimeL()
         assert l is k.GimeL()
 
+    @mark.xfail
     def test14_double_enum_trouble(self):
         """Test a redefinition of enum in a derived class"""
 
@@ -614,7 +615,7 @@ class TestSIGNALS:
         import cppyy
         cls.fragile = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail
+    @mark.crashes
     def test01_abortive_signals(self):
         """Conversion from abortive signals to Python exceptions"""
 

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -51,6 +51,7 @@ class TestREFLEX:
         assert ns.MyData_m1.__init__.__cpp_reflex__(r.RETURN_TYPE, r.AS_TYPE)   == ns.MyData_m1
         assert ns.MyData_m1.__init__.__cpp_reflex__(r.RETURN_TYPE, r.AS_STRING) == 'ReflexTest::MyData_m1'
 
+    @mark.xfail
     def test03_datamember_reflection(self):
         """Data member reflection tooling"""
 

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -20,6 +20,7 @@ class TestOPERATORS:
         import gc
         gc.collect()
 
+    @mark.xfail
     def test01_math_operators(self):
         """Test overloading of math operators"""
 
@@ -43,6 +44,7 @@ class TestOPERATORS:
         assert (number(5)  << 2) == number(20)
         assert (number(20) >> 2) == number(5)
 
+    @mark.xfail
     def test02_unary_math_operators(self):
         """Test overloading of unary math operators"""
 
@@ -60,6 +62,7 @@ class TestOPERATORS:
         nn = -n;
         assert nn == number(-100)
 
+    @mark.xfail
     def test03_comparison_operators(self):
         """Test overloading of comparison operators"""
 
@@ -74,6 +77,7 @@ class TestOPERATORS:
         assert (number(20) != number(10)) == True
         assert (number(20) == number(10)) == False
 
+    @mark.xfail
     def test04_boolean_operator(self):
         """Test implementation of operator bool"""
 
@@ -115,6 +119,7 @@ class TestOPERATORS:
         assert o.m_double == 3.1415
         assert float(o)   == 3.1415
 
+    @mark.xfail
     def test06_approximate_types(self):
         """Test converter operators of approximate types"""
 
@@ -139,6 +144,7 @@ class TestOPERATORS:
         assert round(o.m_float - 3.14, 5) == 0.
         assert round(float(o) - 3.14, 5)  == 0.
 
+    @mark.xfail
     def test07_virtual_operator_eq(self):
         """Test use of virtual bool operator=="""
 
@@ -313,6 +319,7 @@ class TestOPERATORS:
             assert (+n).i ==  42
             #assert (~n).i == ~42
 
+    @mark.xfail
     def test13_comma_operator(self):
         """Comma operator"""
 

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -121,6 +121,7 @@ class TestOVERLOADS:
         assert c_overload().get_int(ah) == 25
         assert d_overload().get_int(ah) == 25
 
+    @mark.xfail
     def test06_double_int_overloads(self):
         """Test overloads on int/doubles"""
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -228,6 +228,7 @@ class TestREGRESSION:
         cppyy.cppdef(code)
         cppyy.gbl.some_foo_calling_python()
 
+    @mark.crashes
     def test10_enum_in_global_space(self):
         """Enum declared in search.h did not appear in global space"""
 
@@ -1018,6 +1019,7 @@ class TestREGRESSION:
         v = cppyy.gbl.std.vector[int]()
         str(v)
 
+    @mark.crashes
     def test35_filesytem(self):
         """Static path object used to crash on destruction"""
 

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -1376,7 +1376,7 @@ class TestSTLITERATOR:
         assert b1 != b2
         assert b1 == e2
 
-    @mark.xfail
+    @mark.crashes
     def test02_STL_like_class_iterators(self):
         """Test the iterator protocol mapping for an STL like class"""
 
@@ -1513,7 +1513,7 @@ class TestSTLARRAY:
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail
+    @mark.crashes
     def test01_array_of_basic_types(self):
         """Usage of std::array of basic types"""
 
@@ -1526,7 +1526,7 @@ class TestSTLARRAY:
             a[i] = i
             assert a[i] == i
 
-    @mark.xfail
+    @mark.crashes
     def test02_array_of_pods(self):
         """Usage of std::array of PODs"""
 
@@ -1550,7 +1550,7 @@ class TestSTLARRAY:
         assert a[2].px == 6
         assert a[2].py == 7
 
-    @mark.xfail
+    @mark.crashes
     def test03_array_of_pointer_to_pods(self):
         """Usage of std::array of pointer to PODs"""
 
@@ -1581,7 +1581,7 @@ class TestSTLARRAY:
             assert gbl.ArrayTest.get_pa_px(a.data(), i) == 13*i
             assert gbl.ArrayTest.get_pa_py(a.data(), i) == 42*i
 
-    @mark.xfail
+    @mark.crashes
     def test04_array_from_aggregate(self):
         """Initialize an array from an aggregate contructor"""
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -173,7 +173,7 @@ class TestTEMPLATES:
         assert call_has_var1(move(Obj1())) == True
         assert call_has_var1(move(Obj2())) == False
 
-    @mark.xfail
+    @mark.crashes
     def test07_type_deduction(self):
         """Traits/type deduction"""
 
@@ -510,6 +510,7 @@ class TestTEMPLATES:
 
         assert round(q.X() - 6.3, 8) == 0.
 
+    @mark.xfail
     def test20_templated_ctor_with_defaults(self):
         """Templated constructor with defaults used to be ignored"""
 
@@ -920,7 +921,7 @@ class TestTEMPLATES:
 
         ns.Templated()       # used to crash
 
-    @mark.xfail
+    @mark.crashes
     def test31_ltlt_in_template_name(self):
         """Verify lookup of template names with << in the name"""
 
@@ -1189,7 +1190,7 @@ class TestTEMPLATED_TYPEDEFS:
         import cppyy
         cls.templates = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail
+    @mark.crashes
     def test01_using(self):
         """Test presence and validity of using typedefs"""
 
@@ -1213,7 +1214,7 @@ class TestTEMPLATED_TYPEDEFS:
         assert in_type_tt.__name__ == 'in_type_tt'
         assert in_type_tt.__cpp_name__ == 'TemplatedTypedefs::DerivedWithUsing<int,TemplatedTypedefs::SomeDummy,4>::in_type_tt'
 
-    @mark.xfail
+    @mark.crashes
     def test02_mapped_type_as_internal(self):
         """Test that mapped types can be used as builtin"""
 
@@ -1242,6 +1243,7 @@ class TestTEMPLATED_TYPEDEFS:
 
         raises(TypeError, tct.__getitem__, 'gibberish', dum, 4)
 
+    @mark.crashes
     def test03_mapped_type_as_template_arg(self):
         """Test that mapped types can be used as template arguments"""
 


### PR DESCRIPTION
This patch should allow us to run the tests more reliably without needing xdist for well-behaved tests.