### PR TITLE
Adapt to the new design changes in libInterOp.

### DIFF
--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -197,7 +197,7 @@ class _stderr_capture(object):
 def cppdef(src):
     """Declare C++ source <src> to Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.InterOp.Declare(gbl.cling.runtime.gCling, src)
+        errcode = gbl.InterOp.Declare(src)
     if not errcode == 0 or err.err:
         if 'warning' in err.err.lower() and not 'error' in err.err.lower():
             warnings.warn(err.err, SyntaxWarning)
@@ -215,7 +215,7 @@ def cppexec(stmt):
     with _stderr_capture() as err:
         errcode = ctypes.c_int(0)
         try:
-            errcode = gbl.InterOp.Process(gbl.cling.runtime.gCling, stmt)
+            errcode = gbl.InterOp.Process(stmt)
         except Exception as e:
             sys.stderr.write("%s\n\n" % str(e))
             if not errcode.value: errcode.value = 1
@@ -231,8 +231,7 @@ def load_library(name):
     """Explicitly load a shared library."""
     with _stderr_capture() as err:
         InterOp = gbl.InterOp
-        gCling = gbl.cling.runtime.gCling
-        result = InterOp.LoadLibrary(gCling, name)
+        result = InterOp.LoadLibrary(name)
     if result == False:
         raise RuntimeError('Could not load library "%s": %s' % (name, err.err))
 
@@ -241,7 +240,7 @@ def load_library(name):
 def include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.InterOp.Declare(gbl.cling.runtime.gCling, '#include "%s"' % header)
+        errcode = gbl.InterOp.Declare('#include "%s"' % header)
     if not errcode == 0:
         raise ImportError('Failed to load header file "%s"%s' % (header, err.err))
     return True
@@ -249,7 +248,7 @@ def include(header):
 def c_include(header):
     """Load (and JIT) header file <header> into Cling."""
     with _stderr_capture() as err:
-        errcode = gbl.InterOp.Declare(gbl.cling.runtime.gCling, """extern "C" {
+        errcode = gbl.InterOp.Declare("""extern "C" {
 #include "%s"
 }""" % header)
     if not errcode == 0:
@@ -260,7 +259,7 @@ def add_include_path(path):
     """Add a path to the include paths available to Cling."""
     if not os.path.isdir(path):
         raise OSError('No such directory: %s' % path)
-    gbl.InterOp.AddIncludePath(gbl.cling.runtime.gCling, path)
+    gbl.InterOp.AddIncludePath(path)
 
 def add_library_path(path):
     """Add a path to the library search paths available to Cling."""
@@ -383,7 +382,7 @@ def sizeof(tt):
         try:
             sz = ctypes.sizeof(tt)
         except TypeError:
-            sz = gbl.InterOp.Evaluate(gbl.cling.runtime.gCling, "sizeof(%s);" % (_get_name(tt),))
+            sz = gbl.InterOp.Evaluate("sizeof(%s);" % (_get_name(tt),))
         _sizes[tt] = sz
         return sz
 

--- a/python/cppyy/__pyinstaller/hook-cppyy.py
+++ b/python/cppyy/__pyinstaller/hook-cppyy.py
@@ -21,7 +21,7 @@ def _backend_files():
 def _api_files():
     import cppyy, os
 
-    # FIXME: Need to use gCling.GetIncludePaths
+    # FIXME: We should add an interface in InterOp.
     paths = str(cppyy.gbl.runtime.gCling.GetIncludePath()).split('-I')
     for p in paths:
         if not p: continue

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -158,26 +158,25 @@ gbl.std.move  = _backend.move
 import os
 def add_default_paths():
     libInterOp = gbl.InterOp
-    gCling = gbl.cling.runtime.gCling
     if os.getenv('CONDA_PREFIX'):
       # MacOS, Linux
         lib_path = os.path.join(os.getenv('CONDA_PREFIX'), 'lib')
-        if os.path.exists(lib_path): libInterOp.AddSearchPath(gCling, lib_path)
+        if os.path.exists(lib_path): libInterOp.AddSearchPath(lib_path)
 
       # Windows
         lib_path = os.path.join(os.getenv('CONDA_PREFIX'), 'Library', 'lib')
-        if os.path.exists(lib_path): libInterOp.AddSearchPath(gCling, lib_path)
+        if os.path.exists(lib_path): libInterOp.AddSearchPath(lib_path)
 
   # assuming that we are in PREFIX/lib/python/site-packages/cppyy, add PREFIX/lib to the search path
     lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, os.path.pardir))
-    if os.path.exists(lib_path): libInterOp.AddSearchPath(gCling, lib_path)
+    if os.path.exists(lib_path): libInterOp.AddSearchPath(lib_path)
 
     try:
         with open('/etc/ld.so.conf') as ldconf:
             for line in ldconf:
                 f = line.strip()
                 if (os.path.exists(f)):
-                    libInterOp.AddSearchPath(gCling, f)
+                    libInterOp.AddSearchPath(f)
     except IOError:
         pass
 add_default_paths()
@@ -193,13 +192,12 @@ default       = _backend.default
 def load_reflection_info(name):
 #    with _stderr_capture() as err:
     InterOp = gbl.InterOp
-    gCling = gbl.cling.runtime.gCling
     #FIXME: Remove the .so and add logic in libinterop
     name = name + ".so"
-    result = InterOp.LoadLibrary(gCling, name)
+    result = InterOp.LoadLibrary(name)
     if name.endswith("Dict.so"):
         header = name[:-7] + ".h";
-        InterOp.Declare(gCling, '#include "' + header +'"')
+        InterOp.Declare('#include "' + header +'"')
 
     if result == False:
         raise RuntimeError('Could not load library "%s"' % (name))

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -322,7 +322,7 @@ class TestCPP11FEATURES:
         assert cppyy.gbl.gMyLambda(2)  == 42
         assert cppyy.gbl.gMyLambda(40) == 80
 
-        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") >= 201402:
+        if cppyy.gbl.InterOp.Evaluate("__cplusplus;") >= 201402:
             cppyy.cppdef("auto gime_a_lambda1() { return []() { return 42; }; }")
             l1 = cppyy.gbl.gime_a_lambda1()
             assert l1
@@ -343,7 +343,7 @@ class TestCPP11FEATURES:
 
         import cppyy
 
-        if 201703 <= cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;"):
+        if 201703 <= cppyy.gbl.InterOp.Evaluate("__cplusplus;"):
             assert cppyy.gbl.std.optional
             assert cppyy.gbl.std.nullopt
 

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -1211,7 +1211,7 @@ class TestCROSSINHERITANCE:
 
         import cppyy
 
-        cppyy.gbl.InterOp.Declare(cppyy.gbl.cling.runtime.gCling, """\
+        cppyy.gbl.InterOp.Declare("""\
         namespace NonStandardOffset {
         struct Calc1 {
           virtual int calc1() = 0;

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -15,7 +15,7 @@ class TestDATATYPES:
         import cppyy
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = 5 #cppyy.gbl.N
-        at_least_17 = 201402 < cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;")
+        at_least_17 = 201402 < cppyy.gbl.InterOp.Evaluate("__cplusplus;")
         cls.has_byte     = at_least_17
         cls.has_optional = at_least_17
 

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -671,7 +671,7 @@ class TestSIGNALS:
 class TestSTDNOTINGLOBAL:
     def setup_class(cls):
         import cppyy
-        cls.has_byte = 201402 < cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;")
+        cls.has_byte = 201402 < cppyy.gbl.InterOp.Evaluate("__cplusplus;")
 
     def test01_stl_in_std(self):
         """STL classes should live in std:: only"""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1031,7 +1031,7 @@ class TestREGRESSION:
 
         import cppyy
 
-        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") > 201402:
+        if cppyy.gbl.InterOp.Evaluate("__cplusplus;") > 201402:
             cppyy.cppdef("""\
             #include <filesystem>
             std::string stack_std_path() {

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -1609,7 +1609,7 @@ class TestSTLSTRING_VIEW:
         """Usage of std::string_view as formal argument"""
 
         import cppyy
-        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") <= 201402:
+        if cppyy.gbl.InterOp.Evaluate("__cplusplus;") <= 201402:
             # string_view exists as of C++17
             return
         countit = cppyy.gbl.StringViewTest.count

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -305,7 +305,7 @@ class TestTEMPLATES:
         assert iavec[5] == 5
 
       # with variadic template
-        if cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "__cplusplus;") > 201402:
+        if cppyy.gbl.InterOp.Evaluate("__cplusplus;") > 201402:
             assert nsup.matryoshka[int, 3].type
             assert nsup.matryoshka[int, 3, 4].type
             assert nsup.make_vector[int , 3]
@@ -313,7 +313,7 @@ class TestTEMPLATES:
             assert nsup.make_vector[int , 4]().m_val == 4
 
       # with inner types using
-        assert cppyy.gbl.InterOp.Evaluate(cppyy.gbl.cling.runtime.gCling, "using_problem::Bar::Foo")
+        assert cppyy.gbl.InterOp.Evaluate("using_problem::Bar::Foo")
         assert nsup.Foo
         assert nsup.Bar.Foo       # used to fail
 


### PR DESCRIPTION
The new changes internalize the interpreter infrastructure and we do not need to pass it externally. That simplifies the API and make it more resilient because often a single change in the implementation might need the interpreter pointer to be passed externally. In that case that would be a breaking change.