### PR TITLE
Mark test as crashes

### DIFF
--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -1549,7 +1549,7 @@ class TestSTLARRAY:
         assert a[2].px == 6
         assert a[2].py == 7
 
-    @mark.xfail
+    @mark.xfail(run=False, reason="Crashes")
     def test03_array_of_pointer_to_pods(self):
         """Usage of std::array of pointer to PODs"""
 


### PR DESCRIPTION
This is because compiler-research/cppyy-backend#76 and compiler-research/CPyCppyy#38 can be merged as they pass many more tests. 

The test crashes at a JIT call so it will be difficult to diagnose.