### PR TITLE
Fix test_aclassloader.py

### DIFF
--- a/test/test_aclassloader.py
+++ b/test/test_aclassloader.py
@@ -8,15 +8,15 @@ test_dct = str(currpath.join("example01Dict"))
 def setup_module(mod):
     setup_make("example01")
 
-
 class TestACLASSLOADER:
 
     def setup_class(cls):
+        cls.test_dct = test_dct
         import cppyy
+        cls.example01 = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail
     def test01_class_autoloading(self):
-        """Test whether a class can be found through .rootmap."""
+        """Test whether a class can be found"""
         import cppyy
         example01_class = cppyy.gbl.example01
         assert example01_class


### PR DESCRIPTION
As we no longer use rootmap to build the test, this usage is deprecated in favour of using InterOp to load libraries like: `cppyy.gbl.Cpp.LoadLibrary(name)`.

This updates the test to follow the same convention as the others by using `cppyy.load_reflection_info` which uses the above API