### PR TITLE
removing xfail on anonymous struct and union tests

### DIFF
--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1558,7 +1558,6 @@ class TestDATATYPES:
                 p = (ctype * len(buf)).from_buffer(buf)
                 assert [p[j] for j in range(width*height)] == [2*j for j in range(width*height)]
 
-    @mark.xfail
     def test31_anonymous_union(self):
         """Anonymous unions place there fields in the parent scope"""
 


### PR DESCRIPTION
fixed by compiler-research/CppInterOp#321