### PR TITLE
force creation of `std::exception` early

### DIFF
--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -85,6 +85,10 @@ sys.modules['cppyy.gbl'] = gbl
 sys.modules['cppyy.gbl.std'] = gbl.std
 
 
+#- force creation of std.exception -------------------------------------------------------
+_e = gbl.std.exception
+
+
 #- enable auto-loading -------------------------------------------------------
 try:    gbl.cling.runtime.gCling.EnableAutoLoading()
 except: pass


### PR DESCRIPTION
`std::exception` is supposed to inherit from `BaseException`
If other classes that inherit `std::exception` are created first, then the Python wrapper class of `std::exception` no longer inherits `BaseException`

---

Towards the exception related bug we were discussing today morning.
Will open another PR at CPyCppyy that should enable 5 additional tests.