### PR TITLE
[test] update tags (#119)

### DIFF
--- a/test/test_advancedcpp.py
+++ b/test/test_advancedcpp.py
@@ -722,7 +722,7 @@ class TestADVANCEDCPP:
         assert len(cppyy.gbl.gtestv1) == 1
         assert len(cppyy.gbl.gtestv2) == 1
 
-    @mark.xfail(run=not IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
+    @mark.xfail(run=False, condition=IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
     def test22_exceptions(self):
         """Catching of C++ exceptions"""
 

--- a/test/test_doc_features.py
+++ b/test/test_doc_features.py
@@ -452,7 +452,7 @@ namespace Namespace {
         assert cppyy.gbl.call_abstract_method1(pc) == "first message"
         assert cppyy.gbl.call_abstract_method2(pc) == "second message"
 
-    @mark.xfail(run=not IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
+    @mark.xfail(run=False, condition=IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
     def test_exceptions(self):
         """Exception throwing and catching"""
 
@@ -1242,7 +1242,7 @@ class TestTALKEXAMPLES:
         assert type(b) == CC.Derived
         assert d is b
 
-    @mark.xfail(run=not IS_MAC_ARM, reason="Seg Faults")
+    @mark.xfail(condition=IS_MAC_ARM, run=False, reason="Seg Faults")
     def test_exceptions(self):
         """Exceptions example"""
 

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -205,7 +205,7 @@ class TestOVERLOADS:
         with raises(ValueError):
             cpp.BoolInt4.fff(2)
 
-    @mark.xfail(run=not IS_MAC_ARM, reason="Seg Faults")
+    @mark.xfail(run=not IS_MAC_ARM, condition=IS_MAC, reason="Seg Faults")
     def test10_overload_and_exceptions(self):
         """Prioritize reporting C++ exceptions from callee"""
 

--- a/test/test_pythonify.py
+++ b/test/test_pythonify.py
@@ -496,7 +496,7 @@ class TestPYTHONIFY:
         with raises(TypeError):
             c.callme(a=1, b=2)
 
-    @mark.xfail
+    @mark.xfail(condition=(not IS_CLANG_REPL) or IS_MAC, reason="Fails on Cling and OSX")
     def test19_keywords_and_defaults(self):
         """Use of keyword arguments mixed with defaults"""
 

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -2030,7 +2030,7 @@ class TestSTLEXCEPTION:
         gc.collect()
         assert cppyy.gbl.GetMyErrorCount() == 0
 
-    @mark.xfail(run=not IS_MAC_ARM, reason="Seg Faults")
+    @mark.xfail(condition=(IS_MAC_X86 and not IS_CLANG_REPL) or IS_MAC_ARM, run=not IS_MAC_ARM, reason="Seg Faults")
     def test04_from_cpp(self):
         """Catch C++ exceptiosn from C++"""
 


### PR DESCRIPTION
fixed by compiler-research/CPyCppyy#74 & compiler-research/cppyy#121 
`test19_keywords_and_defaults` fixed by compiler-research/CPyCppyy#73