### PR TITLE
Install missing dependencies MacOS cppyy jobs

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -442,8 +442,10 @@ jobs:
         brew install gnu-sed boost@1.85 boost-python3 eigen psutils
         if [[ "$ARCHITECHURE" == "x86_64" ]]; then
           CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:/usr/local/opt/boost@1.85/include"
+          CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:/usr/local/opt/Eigen/include"
         else
           CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:/opt/homebrew/opt/boost@1.85/include"
+          CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:/opt/homebrew/opt/Eigen/include"
         fi
         echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
         pip install distro pytest

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -439,9 +439,13 @@ jobs:
           brew link --overwrite "$pkg"
         done
         brew upgrade --force 
-        brew install eigen
-        brew install boost
-        brew install gnu-sed
+        brew install gnu-sed boost@1.85 boost-python3 eigen psutils
+        if [[ "$ARCHITECHURE" == "x86_64" ]]; then
+          CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:/usr/local/opt/boost@1.85/include"
+        else
+          CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:/opt/homebrew/opt/boost@1.85/include"
+        fi
+        echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
         pip install distro pytest
         
 
@@ -463,9 +467,9 @@ jobs:
         if [[ "${cling_on}" == "ON" ]]; then
           CLING_DIR="${{ github.workspace }}/cling"
           CLING_BUILD_DIR="${{ github.workspace }}/cling/build"
-          CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+          CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
         else
-          CPLUS_INCLUDE_PATH="${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+          CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
         fi
 
         export CB_PYTHON_DIR="${{ github.workspace }}/cppyy-backend/python"
@@ -569,6 +573,7 @@ jobs:
         python -m pip install pytest
         python -m pip install pytest-xdist
         python -m pip install numba
+        python -m pip install psutil
         echo ::endgroup::
         echo ::group::Run complete test suite
         set -o pipefail

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -1,11 +1,15 @@
 import py, os, sys
+import cppyy
 from pytest import mark, raises, skip
 from .support import setup_make, IS_CLANG_REPL, IS_MAC_X86, IS_MAC_ARM
 
-noboost = False
-if not (os.path.exists(os.path.join(os.path.sep, 'usr', 'include', 'boost')) or \
-        os.path.exists(os.path.join(os.path.sep, 'usr', 'local', 'include', 'boost'))):
-    noboost = True
+noboost = not cppyy.gbl.Cpp.Evaluate("""
+    #if __has_include("boost/any.hpp")
+        true
+    #else
+        false
+    #endif
+""")
 
 class TestBOOSTANY:
     def setup_class(cls):

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -7,15 +7,12 @@ if not (os.path.exists(os.path.join(os.path.sep, 'usr', 'include', 'boost')) or 
         os.path.exists(os.path.join(os.path.sep, 'usr', 'local', 'include', 'boost'))):
     noboost = True
 
-
-@mark.skipif(noboost == True, reason="boost not found")
 class TestBOOSTANY:
     def setup_class(cls):
         import cppyy
 
         cppyy.include('boost/any.hpp')
 
-    @mark.skipif((IS_MAC_ARM or IS_MAC_X86), reason="Fails to include boost on OS X")
     def test01_any_class(self):
         """Availability of boost::any"""
 
@@ -67,8 +64,6 @@ class TestBOOSTANY:
         extract = boost.any_cast[std.vector[int]](val)
         assert len(extract) == 200
 
-
-@mark.skipif(((noboost == True) or IS_MAC_ARM or IS_MAC_X86), reason="boost not found")
 class TestBOOSTOPERATORS:
     def setup_class(cls):
         import cppyy
@@ -92,8 +87,6 @@ class TestBOOSTOPERATORS:
 
         assert cppyy.gbl.boost_test.Derived
 
-
-@mark.skipif(noboost == True, reason="boost not found")
 class TestBOOSTVARIANT:
     def setup_class(cls):
         import cppyy
@@ -135,7 +128,6 @@ class TestBOOSTVARIANT:
         assert type(boost.get['BV::C'](v[2])) == cpp.BV.C
 
 
-@mark.skipif(((noboost == True) or IS_MAC_ARM or IS_MAC_X86), reason="boost not found")
 class TestBOOSTERASURE:
     def setup_class(cls):
         import cppyy

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -1,6 +1,6 @@
 import py, os, sys
 from pytest import raises, mark
-from .support import setup_make, ispypy, IS_CLANG_REPL, IS_LINUX_ARM
+from .support import setup_make, ispypy, IS_CLANG_REPL, IS_MAC, IS_LINUX_ARM
 
 
 currpath = py.path.local(__file__).dirpath()

--- a/test/test_eigen.py
+++ b/test/test_eigen.py
@@ -1,6 +1,6 @@
 import py, os, sys
 from pytest import mark, raises
-from .support import setup_make, IS_CLANG_REPL, IS_MAC_X86
+from .support import setup_make, IS_CLANG_REPL, IS_MAC_X86, IS_MAC_ARM
 
 inc_paths = [os.path.join(os.path.sep, 'usr', 'include'),
              os.path.join(os.path.sep, 'usr', 'local', 'include')]
@@ -11,8 +11,6 @@ for p in inc_paths:
     if os.path.exists(p):
         eigen_path = p
 
-
-@mark.skipif(eigen_path is None, reason="Eigen not found")
 class TestEIGEN:
     def setup_class(cls):
         import cppyy, warnings
@@ -148,7 +146,6 @@ class TestEIGEN:
         assert a.size() == 9
 
 
-@mark.skipif(eigen_path is None, reason="Eigen not found")
 class TestEIGEN_REGRESSIOn:
     def setup_class(cls):
         import cppyy, warnings
@@ -158,7 +155,7 @@ class TestEIGEN_REGRESSIOn:
             warnings.simplefilter('ignore')
             cppyy.include('Eigen/Dense')
 
-    @mark.xfail(condition=IS_MAC_X86 and (not IS_CLANG_REPL), reason="Errors out on OS X Cling")
+    @mark.xfail(condition=((IS_MAC_ARM) or (IS_MAC_X86 and not IS_CLANG_REPL)), reason="Fails on OS X arm and osx 86 for cling")
     def test01_use_of_Map(self):
         """Use of Map (used to crash)"""
 

--- a/test/test_eigen.py
+++ b/test/test_eigen.py
@@ -1,24 +1,26 @@
 import py, os, sys
+import cppyy
 from pytest import mark, raises
 from .support import setup_make, IS_CLANG_REPL, IS_MAC_X86, IS_MAC_ARM
 
 inc_paths = [os.path.join(os.path.sep, 'usr', 'include'),
              os.path.join(os.path.sep, 'usr', 'local', 'include')]
 
-eigen_path = None
-for p in inc_paths:
-    p = os.path.join(p, 'eigen3')
-    if os.path.exists(p):
-        eigen_path = p
+noeigen = not cppyy.gbl.Cpp.Evaluate("""
+    #if __has_include("eigen3/Eigen/Dense")
+        true
+    #else
+        false
+    #endif
+""")
 
+@mark.skipif(noeigen == True, reason="Eigen not found")
 class TestEIGEN:
     def setup_class(cls):
         import cppyy, warnings
 
-        cppyy.add_include_path(eigen_path)
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            cppyy.include('Eigen/Dense')
+            cppyy.include('eigen3/Eigen/Dense')
 
     @mark.xfail
     def test01_simple_matrix_and_vector(self):
@@ -146,14 +148,14 @@ class TestEIGEN:
         assert a.size() == 9
 
 
-class TestEIGEN_REGRESSIOn:
+@mark.skipif(noeigen == True, reason="Eigen not found")
+class TestEIGEN_REGRESSION:
     def setup_class(cls):
         import cppyy, warnings
 
-        cppyy.add_include_path(eigen_path)
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            cppyy.include('Eigen/Dense')
+            cppyy.include('eigen3/Eigen/Dense')
 
     @mark.xfail(condition=((IS_MAC_ARM) or (IS_MAC_X86 and not IS_CLANG_REPL)), reason="Fails on OS X arm and osx 86 for cling")
     def test01_use_of_Map(self):

--- a/test/test_leakcheck.py
+++ b/test/test_leakcheck.py
@@ -1,6 +1,6 @@
 import py, os, sys
 from pytest import mark, skip
-from .support import setup_make, pylong, pyunicode, IS_CLANG_REPL
+from .support import setup_make, pylong, pyunicode, IS_CLANG_REPL, IS_MAC
 
 currpath = py.path.local(__file__).dirpath()
 test_dct = str(currpath.join("datatypesDict"))
@@ -67,6 +67,7 @@ class TestLEAKCHECK:
         gc.collect()
         assert last == self.process.memory_info().rss
 
+    @mark.xfail(condition=IS_MAC, reason="Fails on OS X")
     def test01_free_functions(self):
         """Leak test of free functions"""
 
@@ -92,6 +93,7 @@ class TestLEAKCHECK:
         self.check_func(ns, 'free_f_ret1')
         self.check_func(ns, 'free_f_ret1')
 
+    @mark.xfail(condition=IS_MAC, reason="Fails on OS X")
     def test02_test_static_methods(self):
         """Leak test of static methods"""
 
@@ -118,6 +120,7 @@ class TestLEAKCHECK:
             self.check_func(m, 'static_method_ol', 42., tmpl_args='float')
             self.check_func(m, 'static_method_ret')
 
+    @mark.xfail(condition=IS_MAC, reason="Fails on OS X")
     def test03_test_methods(self):
         """Leak test of methods"""
 

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -1,6 +1,6 @@
 import py, os, sys
 from pytest import raises, skip, mark
-from .support import setup_make, pylong, pyunicode, IS_WINDOWS, ispypy, IS_CLANG_REPL, IS_MAC
+from .support import setup_make, pylong, pyunicode, IS_WINDOWS, ispypy, IS_CLANG_REPL, IS_MAC, IS_MAC_X86
 
 currpath = py.path.local(__file__).dirpath()
 test_dct = str(currpath.join("datatypesDict"))

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -484,7 +484,7 @@ class TestLOWLEVEL:
         assert cppyy.gbl.std.vector[cppyy.gbl.std.vector[int]].value_type == 'std::vector<int>'
         assert cppyy.gbl.std.vector['int[1]'].value_type == 'int[1]'
 
-    @mark.xfail
+    @mark.skip
     def test15_templated_arrays_gmpxx(self):
         """Use of gmpxx array types in templates"""
 

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -484,7 +484,7 @@ class TestLOWLEVEL:
         assert cppyy.gbl.std.vector[cppyy.gbl.std.vector[int]].value_type == 'std::vector<int>'
         assert cppyy.gbl.std.vector['int[1]'].value_type == 'int[1]'
 
-    @mark.skip
+    @mark.xfail(run=not (IS_MAC_X86 and not IS_CLANG_REPL), reason="Crashes on OSX-X86 Cling")
     def test15_templated_arrays_gmpxx(self):
         """Use of gmpxx array types in templates"""
 


### PR DESCRIPTION
There are a lot of tests failing for things simply not being installed on MacOS. Hopefully by installing these cppyy will get more passing tests on MacOS. See here about missing dependencies https://github.com/compiler-research/CppInterOp/actions/runs/12925582648/job/36047197449#step:14:7103 