### PR TITLE
[test] update tags

### DIFF
--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -21,7 +21,6 @@ class TestDATATYPES:
         cls.has_byte     = at_least_17
         cls.has_optional = at_least_17
 
-    @mark.xfail(run=False, reason="Crashes")
     def test01_instance_data_read_access(self):
         """Read access to instance public data and verify values"""
 
@@ -1333,7 +1332,7 @@ class TestDATATYPES:
         ns = cppyy.gbl.FuncPtrReturn
         assert ns.foo()() == "Hello, World!"
 
-    @mark.xfail(run=not(((IS_CLANG_REPL and IS_MAC) or (not IS_CLANG_REPL and IS_MAC))), reason="Crashes")
+    @mark.xfail(run=False, condition=(IS_CLANG_REPL and IS_MAC) or (not IS_CLANG_REPL and IS_MAC), reason="Crashes")
     def test27_callable_passing(self):
         """Passing callables through function pointers"""
 
@@ -1406,7 +1405,7 @@ class TestDATATYPES:
         gc.collect()
         raises(TypeError, c, 3, 3) # lambda gone out of scope
 
-    @mark.xfail(run=not IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
+    @mark.xfail(run=False, condition=IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
     def test28_callable_through_function_passing(self):
         """Passing callables through std::function"""
 

--- a/test/test_doc_features.py
+++ b/test/test_doc_features.py
@@ -261,7 +261,7 @@ namespace Namespace {
 
         pass
 
-    @mark.xfail(run=not IS_MAC, reason="Seg Fault")
+    @mark.xfail(run=False, condition=IS_MAC, reason="Seg Fault")
     def test_functions(self):
         import cppyy
 


### PR DESCRIPTION
`test01_instance_data_read_access` fixed by compiler-research/cppyy-backend#128 (enum changes)
others fixed by compiler-research/CPyCppyy#82 & compiler-research/CppInterOp#502