### PR TITLE
Make sure <new> is included before testing

### DIFF
--- a/test/test_advancedcpp.py
+++ b/test/test_advancedcpp.py
@@ -591,7 +591,7 @@ class TestADVANCEDCPP:
         """Verify that class-level overloaded new/delete are called"""
 
         import cppyy
-
+        cppyy.include("new")
         assert cppyy.gbl.new_overloader.s_instances == 0
         nl = cppyy.gbl.new_overloader()
         assert cppyy.gbl.new_overloader.s_instances == 1


### PR DESCRIPTION
This should address the failure in https://github.com/compiler-research/CppInterOp/pull/912