### PR TITLE
Fix syntax errors in tests

### DIFF
--- a/test/test_advancedcpp.py
+++ b/test/test_advancedcpp.py
@@ -722,7 +722,7 @@ class TestADVANCEDCPP:
         assert len(cppyy.gbl.gtestv1) == 1
         assert len(cppyy.gbl.gtestv2) == 1
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
+    @mark.xfail(IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
     def test22_exceptions(self):
         """Catching of C++ exceptions"""
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -64,7 +64,7 @@ class TestAPI:
         m2 = API.Instance_FromVoidPtr(voidp, 'APICheck2')
         assert m is m2
 
-    @mark.xfail(run=False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
+    @mark.xfail(IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
     def test04_custom_converter(self):
         """Custom type converter"""
 

--- a/test/test_concurrent.py
+++ b/test/test_concurrent.py
@@ -166,7 +166,7 @@ class TestCONCURRENT:
         assert "RuntimeError" in w.err_msg
         assert "all wrong"    in w.err_msg
 
-    @mark.xfail(run=False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
+    @mark.xfail(IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
     def test05_float2d_callback(self):
         """Passing of 2-dim float arguments"""
 

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -87,7 +87,7 @@ class TestCONVERSIONS:
         gc.collect()
         assert CC.s_count == 0
 
-    @mark.xfail(run=IS_CLANG_REPL, condition = IS_MAC or IS_CLING, reason = "Crashes on Cling")
+    @mark.xfail(IS_CLANG_REPL and (IS_MAC or IS_CLING),reason="Crashes on Cling")
     def test04_implicit_conversion_from_tuple(self):
         """Allow implicit conversions from tuples as arguments {}-like"""
 

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -87,7 +87,7 @@ class TestCONVERSIONS:
         gc.collect()
         assert CC.s_count == 0
 
-    @mark.xfail(IS_CLANG_REPL and (IS_MAC or IS_CLING),reason="Crashes on Cling")
+    @mark.xfail(IS_MAC,reason="Crashes on Cling")
     def test04_implicit_conversion_from_tuple(self):
         """Allow implicit conversions from tuples as arguments {}-like"""
 

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -15,7 +15,7 @@ class TestCPP11FEATURES:
         import cppyy
         cls.cpp11features = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(run=False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
+    @mark.xfail(IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
     def test01_smart_ptr(self):
         """Usage and access of std::shared/unique_ptr<>"""
 

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -36,7 +36,7 @@ class TestCROSSINHERITANCE:
         assert Base1.call_get_value(Base1())   == 42
         assert Base1.call_get_value(Derived()) == 13
 
-    @mark.xfail(run=False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
+    @mark.xfail(IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
     def test02_constructor(self):
         """Test constructor usage for derived classes"""
 

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1251,7 +1251,7 @@ class TestDATATYPES:
         run(self, cppyy.gbl.sum_uc_data, buf, total)
         run(self, cppyy.gbl.sum_byte_data, buf, total)
 
-    @mark.xfail(IS_MAC, reason="Crashes on OSX")
+    @mark.skipif(IS_MAC, reason="Crashes on OSX")
     def test26_function_pointers(self):
         """Function pointer passing"""
 

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1251,7 +1251,7 @@ class TestDATATYPES:
         run(self, cppyy.gbl.sum_uc_data, buf, total)
         run(self, cppyy.gbl.sum_byte_data, buf, total)
 
-    @mark.xfail(run=False, condition=IS_MAC, reason="Crashes on OSX")
+    @mark.xfail(IS_MAC, reason="Crashes on OSX")
     def test26_function_pointers(self):
         """Function pointer passing"""
 

--- a/test/test_doc_features.py
+++ b/test/test_doc_features.py
@@ -260,7 +260,7 @@ namespace Namespace {
 
         pass
 
-    @mark.xfail(run=False, condition=IS_MAC, reason="Seg Fault")
+    @mark.xfail(IS_MAC, reason="Seg Fault")
     def test_functions(self):
         import cppyy
 

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -135,7 +135,7 @@ class TestLOWLEVEL:
         f = array('f', [0]);     ctd.set_float_r(f);  assert f[0] ==  5.
         f = array('d', [0]);     ctd.set_double_r(f); assert f[0] == -5.
 
-    @mark.xfail(run=False, condition=IS_VALGRIND or IS_CLING, reason="Valgrind detects memory leak with invalid delete[] operator, crashes on Cling") 
+    @mark.xfail(IS_VALGRIND or IS_CLING, reason="Valgrind detects memory leak with invalid delete[] operator, crashes on Cling") 
     def test06_ctypes_as_ref_and_ptr(self):
         """Use ctypes for pass-by-ref/ptr"""
 

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -465,7 +465,7 @@ class TestNUMBA:
         assert b.value == z + k
         assert c.value == y + k
 
-    @mark.xfail(run=False, condition=IS_LINUX_ARM, reason="Crash in llvmlite on Linux ARM")
+    @mark.xfail(IS_LINUX_ARM, reason="Crash in llvmlite on Linux ARM")
     def test12_std_vector_pass_by_ref(self):
         """Numba-JITing of a method that performs scalar addition to a std::vector initialised through pointers """
         import cppyy

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -205,7 +205,7 @@ class TestOVERLOADS:
         with raises(ValueError):
             cpp.BoolInt4.fff(2)
 
-    @mark.xfail(IS_MAC and not IS_MAC_ARM, reason="Seg Faults")
+    @mark.xfail(IS_MAC, reason="Seg Faults")
     def test10_overload_and_exceptions(self):
         """Prioritize reporting C++ exceptions from callee"""
 

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -205,7 +205,7 @@ class TestOVERLOADS:
         with raises(ValueError):
             cpp.BoolInt4.fff(2)
 
-    @mark.xfail(run=not IS_MAC_ARM, condition=IS_MAC, reason="Seg Faults")
+    @mark.xfail(IS_MAC and not IS_MAC_ARM, reason="Seg Faults")
     def test10_overload_and_exceptions(self):
         """Prioritize reporting C++ exceptions from callee"""
 

--- a/test/test_pythonization.py
+++ b/test/test_pythonization.py
@@ -148,7 +148,7 @@ class TestClassPYTHONIZATION:
         assert mine.__smartptr__().get().m_check == 0xcdcdcdcd
         assert mine.say_hi() == "Hi!"
 
-    @mark.xfail(run=False, condition=IS_VALGRIND and IS_LINUX_ARM and IS_CLANG_REPL, reason="Crashes on Valgind Clang-Repl-ARM")
+    @mark.xfail(IS_VALGRIND and IS_LINUX_ARM and IS_CLANG_REPL,reason="Crashes on Valgrind Clang-Repl-ARM")
     def test05_converters(self):
         """Smart pointer argument passing"""
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -197,7 +197,7 @@ class TestREGRESSION:
 
         assert sys.getrefcount(x) == old_refcnt
 
-    @mark.xfail(run=False, condition=IS_MAC and IS_CLING, reason="Crahes on OSX-Cling")
+    @mark.xfail(IS_MAC and IS_CLING, reason="Crahes on OSX-Cling")
     def test08_typedef_identity(self):
         """Nested typedefs should retain identity"""
 

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -391,7 +391,7 @@ class TestSTLVECTOR:
         assert v2[-1] == v[-2]
         assert v2[self.N-4] == v[-2]
 
-    @mark.xfail(run=False, condition=(IS_MAC and IS_CLING), reason="Crashes on OSX Cling")
+    @mark.xfail(IS_MAC and IS_CLING, reason="Crashes on OSX Cling")
     def test07_vector_bool(self):
         """Usability of std::vector<bool> which can be a specialization"""
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -276,7 +276,7 @@ class TestTEMPLATES:
         assert round(RTTest2[int](1, 3.1).m_double - 4.1, 8) == 0.
         assert round(RTTest2[int]().m_double + 1., 8) == 0.
 
-    @mark.xfail(run=False, condition=IS_CLING, reason="Crashes on Cling")
+    @mark.xfail(IS_CLING, reason="Crashes on Cling")
     def test12_template_aliases(self):
         """Access to templates made available with 'using'"""
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -276,7 +276,7 @@ class TestTEMPLATES:
         assert round(RTTest2[int](1, 3.1).m_double - 4.1, 8) == 0.
         assert round(RTTest2[int]().m_double + 1., 8) == 0.
 
-    @mark.xfail(IS_CLING, reason="Crashes on Cling")
+    @mark.skipif(IS_CLING, reason="Crashes on Cling")
     def test12_template_aliases(self):
         """Access to templates made available with 'using'"""
 


### PR DESCRIPTION
In the ci we currently get these syntax errors about the tests. This PR is an attempt to fix them in case it allows us to run more tests

```
==================================== ERRORS ====================================
  __________________ ERROR collecting test/test_advancedcpp.py ___________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_advancedcpp.py", line 725
  E       @mark.skipif(condition=not False, condition=IS_MAC_ARM, reason="Crashes with exception not being caught on Apple Silicon")
  E                                         ^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ______________________ ERROR collecting test/test_api.py _______________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_api.py", line 67
  E       @mark.skipif(condition=not False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ___________________ ERROR collecting test/test_concurrent.py ___________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_concurrent.py", line 169
  E       @mark.skipif(condition=not False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  __________________ ERROR collecting test/test_conversions.py ___________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_conversions.py", line 90
  E       @mark.skipif(condition=not IS_CLANG_REPL, condition = IS_MAC or IS_CLING, reason = "Crashes on Cling")
  E                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  _________________ ERROR collecting test/test_cpp11features.py __________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_cpp11features.py", line 18
  E       @mark.skipif(condition=not False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ________________ ERROR collecting test/test_crossinheritance.py ________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_crossinheritance.py", line 39
  E       @mark.skipif(condition=not False, condition=IS_LINUX_ARM, reason="Crashes pytest on Linux ARM")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ___________________ ERROR collecting test/test_datatypes.py ____________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_datatypes.py", line 1254
  E       @mark.skipif(condition=not False, condition=IS_MAC, reason="Crashes on OSX")
  E                                         ^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  __________________ ERROR collecting test/test_doc_features.py __________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_doc_features.py", line 263
  E       @mark.skipif(condition=not False, condition=IS_MAC, reason="Seg Fault")
  E                                         ^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ____________________ ERROR collecting test/test_lowlevel.py ____________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_lowlevel.py", line 138
  E       @mark.skipif(condition=not False, condition=IS_VALGRIND or IS_CLING, reason="Valgrind detects memory leak with invalid delete[] operator, crashes on Cling") 
  E                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  _____________________ ERROR collecting test/test_numba.py ______________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_numba.py", line 468
  E       @mark.skipif(condition=not False, condition=IS_LINUX_ARM, reason="Crash in llvmlite on Linux ARM")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ___________________ ERROR collecting test/test_overloads.py ____________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_overloads.py", line 208
  E       @mark.skipif(condition=not not IS_MAC_ARM, condition=IS_MAC, reason="Seg Faults")
  E                                                  ^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  _________________ ERROR collecting test/test_pythonization.py __________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_pythonization.py", line 151
  E       @mark.skipif(condition=not False, condition=IS_VALGRIND and IS_LINUX_ARM and IS_CLANG_REPL, reason="Crashes on Valgind Clang-Repl-ARM")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ___________________ ERROR collecting test/test_regression.py ___________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_regression.py", line 200
  E       @mark.skipif(condition=not False, condition=IS_MAC and IS_CLING, reason="Crahes on OSX-Cling")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ____________________ ERROR collecting test/test_stltypes.py ____________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_stltypes.py", line 394
  E       @mark.skipif(condition=not False, condition=(IS_MAC and IS_CLING), reason="Crashes on OSX Cling")
  E                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition
  ___________________ ERROR collecting test/test_templates.py ____________________
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/python.py:507: in importtestmodule
      mod = import_path(
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/pathlib.py:587: in import_path
      importlib.import_module(module_name)
  /opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  <frozen importlib._bootstrap>:1406: in _gcd_import
      ???
  <frozen importlib._bootstrap>:1371: in _find_and_load
      ???
  <frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
      ???
  <frozen importlib._bootstrap>:938: in _load_unlocked
      ???
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
      source_stat, co = _rewrite_test(fn, self.config)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ../CppInterOp/.venv/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
      co = compile(tree, strfn, "exec", dont_inherit=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E     File "/home/runner/work/cppyy/cppyy/test/test_templates.py", line 279
  E       @mark.skipif(condition=not False, condition=IS_CLING, reason="Crashes on Cling")
  E                                         ^^^^^^^^^^^^^^^^^^
  E   SyntaxError: keyword argument repeated: condition

Give me a summary of these syntax errors
```