### PR TITLE
Mark `test16_unique_ptr_moves` as failing on all mac platforms

### DIFF
--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -1,6 +1,6 @@
 import py, os, sys
 from pytest import raises, mark
-from support import setup_make, ispypy, IS_CLANG_REPL, IS_CLING, IS_LINUX_ARM, IS_LINUX, IS_MAC, IS_MAC_ARM, IS_VALGRIND
+from support import setup_make, ispypy, IS_CLANG_REPL, IS_CLING, IS_LINUX_ARM, IS_LINUX, IS_MAC, IS_VALGRIND
 
 
 currpath = py.path.local(__file__).dirpath()
@@ -450,7 +450,7 @@ class TestCPP11FEATURES:
         with raises(ValueError):  # not an RValue
             cppyy.gbl.UniqueTempl.returnptr[int](uptr_in)
 
-    @mark.xfail(IS_MAC_ARM, reason = "Fails on ARM Mac platforms")
+    @mark.xfail(IS_MAC, reason = "Fails on Mac platforms")
     def test16_unique_ptr_moves(self):
         """std::unique_ptr requires moves"""
 


### PR DESCRIPTION
This was marked as failing on Mac ARM but in reality it was the OS X 26 SDK that caused this failure. CppInterOp's CI no longer runs OS X 15 which passed the x86 jobs in the original PR.