### PR TITLE
[ci] Drop OSX 15 SDK jobs

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -48,32 +48,6 @@ jobs:
             root-llvm-tag: 'cling-llvm20-20260119-01'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: osx15-x86-clang-clang-repl-21
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '21'
-            python-version: '3.14'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-          - name: osx15-x86-clang-clang-repl-20
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '20'
-            python-version: '3.13'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-          - name: osx15-x86-clang-clang20-cling
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '20'
-            python-version: '3.14'
-            cling: On
-            cling-version: '1.3'
-            root-llvm-tag: 'cling-llvm20-20260119-01'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
             
     steps:
     - uses: actions/checkout@v4
@@ -271,29 +245,6 @@ jobs:
             cppyy: On
           - name: osx26-arm-clang-clang20-cling-cppyy
             os: macos-26
-            compiler: clang
-            clang-runtime: '20'
-            python-version: '3.14'
-            cling: On
-            cling-version: '1.3'
-            root-llvm-tag: 'cling-llvm20-20260119-01'
-            cppyy: On
-          - name: osx15-x86-clang-clang-repl-21-cppyy
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '21'
-            python-version: '3.14'
-            cling: Off
-            cppyy: On
-          - name: osx15-x86-clang-clang-repl-20-cppyy
-            os: macos-15-intel
-            compiler: clang
-            clang-runtime: '20'
-            python-version: '3.13'
-            cling: Off
-            cppyy: On
-          - name: osx15-x86-clang-clang20-cling-cppyy
-            os: macos-15-intel
             compiler: clang
             clang-runtime: '20'
             python-version: '3.14'

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -1,7 +1,7 @@
 import py, os, sys
 import math, time
 from pytest import mark, raises
-from .support import setup_make, IS_LINUX_ARM
+from .support import setup_make, IS_LINUX_ARM, IS_VALGRIND
 
 try:
     import numba
@@ -9,6 +9,8 @@ try:
 except ImportError:
     has_numba = False
 
+if IS_LINUX_ARM and IS_VALGRIND:
+    has_numba = False
 
 class TestREFLEX:
     def setup_class(cls):


### PR DESCRIPTION
Follow CppInterOp that dropped the older SDK versions from the CI. Also skip the numba tests on ARM linux platforms that sporadically complain about an invalid instruction with valgrind