### PR TITLE
Fix m_schar_array2 leak in test support code

### DIFF
--- a/test/datatypes.cxx
+++ b/test/datatypes.cxx
@@ -105,6 +105,7 @@ CppyyTestData::~CppyyTestData()
 void CppyyTestData::destroy_arrays() {
     if (m_owns_arrays == true) {
         delete[] m_bool_array2;
+        delete[] m_schar_array2;
         delete[] m_uchar_array2;
         delete[] m_byte_array2;
         delete[] m_int8_array2;


### PR DESCRIPTION
`destroy_arrays()` deletes every 2D test array except `m_schar_array2`, which is allocated alongside them in the ctor. Add the missing `delete[]`.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)