### PR TITLE
Test auto-downcast objects returned through smart pointers

### DIFF
--- a/test/cpp11features.cxx
+++ b/test/cpp11features.cxx
@@ -40,6 +40,18 @@ TestSmartPtr create_TestSmartPtr_by_value() {
     return TestSmartPtr{};
 }
 
+std::shared_ptr<TestSmartPtr> create_shared_ptr_to_derived() {
+    return std::shared_ptr<TestSmartPtr>(new PubDerivedTestSmartPtr);
+}
+
+std::unique_ptr<TestSmartPtr> create_unique_ptr_to_derived() {
+    return std::unique_ptr<TestSmartPtr>(new PubDerivedTestSmartPtr);
+}
+
+std::unique_ptr<TestSmartPtrIface> create_unique_ptr_to_offset_derived() {
+    return std::unique_ptr<TestSmartPtrIface>(new MultiDerivedTestSmartPtr);
+}
+
 
 // for move ctors etc.
 int TestMoving1::s_move_counter = 0;

--- a/test/cpp11features.h
+++ b/test/cpp11features.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 
@@ -38,6 +39,48 @@ int move_unique_ptr(std::unique_ptr<TestSmartPtr>&& p);
 int move_unique_ptr_derived(std::unique_ptr<DerivedTestSmartPtr>&& p);
 
 TestSmartPtr create_TestSmartPtr_by_value();
+
+// for auto-downcast of objects returned through a smart pointer
+class PubDerivedTestSmartPtr : public TestSmartPtr {
+public:
+    int only_in_derived() { return 27; }
+};
+
+// second base so that the cross-cast to the most derived type needs a
+// non-zero pointer adjustment, which the smart pointer's dereferencer can
+// not apply consistently (so no down-cast should happen in that case)
+class TestSmartPtrIface {
+public:
+    virtual ~TestSmartPtrIface() {}
+    long m_pad = 0;
+    int only_in_iface() { return 37; }
+};
+
+class MultiDerivedTestSmartPtr : public PubDerivedTestSmartPtr, public TestSmartPtrIface {
+};
+
+std::shared_ptr<TestSmartPtr> create_shared_ptr_to_derived();
+std::unique_ptr<TestSmartPtr> create_unique_ptr_to_derived();
+std::unique_ptr<TestSmartPtrIface> create_unique_ptr_to_offset_derived();
+
+// sinks expecting a smart pointer to the *derived* type; a base-class smart
+// pointer (even when its object was auto-down-cast) must not be accepted here
+int pass_unique_ptr_to_derived(std::unique_ptr<PubDerivedTestSmartPtr> p) {
+    return p->only_in_derived();
+}
+
+int pass_shared_ptr_to_derived(std::shared_ptr<PubDerivedTestSmartPtr> p) {
+    return p->only_in_derived();
+}
+
+// Overloaded function to check if automatic downcasting is consistently
+// applied for regular proxy objects and smart pointer proxies.
+std::string pass_ptr_overloaded(TestSmartPtr *) { return "TestSmartPtr"; }
+std::string pass_ptr_overloaded(PubDerivedTestSmartPtr *) { return "PubDerivedTestSmartPtr"; }
+std::string pass_ref_overloaded(TestSmartPtr &) { return "TestSmartPtr"; }
+std::string pass_ref_overloaded(PubDerivedTestSmartPtr &) { return "PubDerivedTestSmartPtr"; }
+std::string pass_val_overloaded(TestSmartPtr) { return "TestSmartPtr"; }
+std::string pass_val_overloaded(PubDerivedTestSmartPtr) { return "PubDerivedTestSmartPtr"; }
 
 
 //===========================================================================

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -566,3 +566,50 @@ class TestCPP11FEATURES:
              return ns.dummy_create()
 
         assert ns.call_creator(pyfunc)
+
+    def test21_smart_ptr_downcast(self):
+        """Object returned through a smart pointer is auto-downcast"""
+
+        import cppyy
+
+        gbl = cppyy.gbl
+
+        # unique_ptr<Base> holding a Derived comes back as Derived, with the
+        # derived-only method callable, just like a raw pointer return
+        for cf in [gbl.create_unique_ptr_to_derived, gbl.create_shared_ptr_to_derived]:
+            obj = cf()
+            assert type(obj) == gbl.PubDerivedTestSmartPtr
+            assert obj.only_in_derived() == 27
+            assert obj.__smartptr__()      # smart-pointer semantics preserved
+
+        # an object that really is of the declared type stays that type
+        obj = gbl.create_unique_ptr_instance()
+        assert type(obj) == gbl.TestSmartPtr
+
+        # the most derived type sits at a non-zero offset from the declared
+        # interface, which the dereferencer can not apply: stay the declared
+        # type and keep behaving correctly
+        obj = gbl.create_unique_ptr_to_offset_derived()
+        assert type(obj) == gbl.TestSmartPtrIface
+        assert obj.only_in_iface() == 37
+
+        # the auto-down-cast must not enable C++-invalid conversions: the proxy
+        # still embeds a smart pointer to the *base* type, which does not convert
+        # to a smart pointer to the derived type (no implicit down-conversion of
+        # smart pointers in C++), so passing it to such a sink must be rejected
+        raises(TypeError, gbl.pass_unique_ptr_to_derived, gbl.create_unique_ptr_to_derived())
+        raises(TypeError, gbl.pass_shared_ptr_to_derived, gbl.create_shared_ptr_to_derived())
+
+        # passing it where the matching base smart pointer is expected still works
+        assert gbl.pass_shared_ptr(gbl.create_shared_ptr_to_derived()) == 17
+
+        # calling function with overloads for both the base class and the
+        # derived class should resolve to the downcasted type overload,
+        # no matter if the Python proxy is a regular proxy or wraps a smart pointer
+        # (should hold for pointer, reference, and value types)
+        assert gbl.pass_ptr_overloaded(gbl.PubDerivedTestSmartPtr()) == "PubDerivedTestSmartPtr"
+        assert gbl.pass_ptr_overloaded(gbl.create_unique_ptr_to_derived()) == "PubDerivedTestSmartPtr"
+        assert gbl.pass_ref_overloaded(gbl.PubDerivedTestSmartPtr()) == "PubDerivedTestSmartPtr"
+        assert gbl.pass_ref_overloaded(gbl.create_unique_ptr_to_derived()) == "PubDerivedTestSmartPtr"
+        assert gbl.pass_val_overloaded(gbl.PubDerivedTestSmartPtr()) == "PubDerivedTestSmartPtr"
+        assert gbl.pass_val_overloaded(gbl.create_unique_ptr_to_derived()) == "PubDerivedTestSmartPtr"


### PR DESCRIPTION
Tests for https://github.com/compiler-research/CPyCppyy/pull/211

Corresponds to ROOT commit:
https://github.com/root-project/root/commit/6f366acb6b638de9b0a3560ee6e28f04536c540f