### PR TITLE
Un-xfail bool enum and std::array iteration tests (#198)

### DIFF
--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -764,8 +764,9 @@ class TestDATATYPES:
 
         assert sc.vraioufaux.faux == False
         assert sc.vraioufaux.vrai == True
-        assert type(sc.vraioufaux.faux) == bool  # no bool as base class
-        assert isinstance(sc.vraioufaux.faux, bool)
+        assert type(sc.vraioufaux.faux) == sc.vraioufaux
+        assert isinstance(sc.vraioufaux.faux, int)   # no bool as base class
+        assert 'bool' in repr(sc.vraioufaux.faux)
 
     def test12_enum_scopes(self):
         """Enum accessibility and scopes"""
@@ -2339,7 +2340,6 @@ class TestDATATYPES:
         assert [ns.test[i]  for i in range(6)] == [-0x12, -0x34, -0x56, -0x78, 0x0, 0x0]
         assert [ns.utest[i] for i in range(6)] == [ 0x12,  0x34,  0x56,  0x78, 0x0, 0x0]
 
-    @mark.xfail(reason="enum class : bool is broken, doesn't populate underlying _member_names_, for example")
     def test51_enum_integrity(self):
         import cppyy
         import enum

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -1697,7 +1697,6 @@ class TestSTLARRAY:
         with raises(TypeError):
             cppyy.gbl.std.array["double",3](['a', 1.0, 1.0])
 
-    @mark.xfail(reason="std::array<nanoseconds> iteration fails")
     def test05_array_of_chrono_types_should_be_iterable(self):
         import cppyy
         cppyy.cppdef("""
@@ -1706,9 +1705,7 @@ class TestSTLARRAY:
         std::vector<std::chrono::nanoseconds>   vtimes  = {10ns, 500ns, 1us};
         std::array<std::chrono::nanoseconds, 3> atimes = {10ns, 500ns, 1us};
         """)
-        # this works normally...
         assert sum([v.count() for v in cppyy.gbl.vtimes]) == 1510
-        # ... but this doesn't, fails complaining about not being able to iterate
         assert sum([v.count() for v in cppyy.gbl.atimes]) == 1510
 
 


### PR DESCRIPTION
Test side of #198. Depends on compiler-research/cppyy-backend#215 and compiler-research/CPyCppyy#221 — CI here will stay red until both merge.

- Un-xfails `test51_enum_integrity` and `TestSTLARRAY::test05_array_of_chrono_types_should_be_iterable`.
- Updates the bool-enum type assertions in `test11_typed_enums`: values are now instances of the enum class (int-based), matching the other underlying types.

With both fixes: 510 passed, 69 skipped, 17 xfailed, 0 failures.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)