### PR TITLE
Add regression test for void* overload priority

### DIFF
--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -400,3 +400,33 @@ class TestOVERLOADS:
         ptr = cppyy.gbl.MyClass()
 
         raises(TypeError, cppyy.gbl.changePtr, ptr)
+
+    def test16_voidp_does_not_outrank_conversion(self):
+        """Verify that a const void* overload does not shadow a converting one.
+        """
+
+        import cppyy
+
+        cppyy.cppdef("""
+        namespace VoidPPriority {
+        struct Handle {
+            void* data;
+            Handle() : data(nullptr) {}
+            Handle(void* p) : data(p) {}
+        };
+        struct ConstHandle {
+            const void* data;
+            ConstHandle() : data(nullptr) {}
+            ConstHandle(const void* p) : data(p) {}   // declared first on purpose
+            ConstHandle(Handle h) : data(h.data) {}
+        };
+        Handle make_handle() { return Handle((void*)0xABCD1234); }
+        bool kept_value(ConstHandle c) { return c.data == (const void*)0xABCD1234; }
+        }""")
+
+        ns = cppyy.gbl.VoidPPriority
+
+        # taking ConstHandle(const void*) would pass the proxy's address instead
+        h = ns.make_handle()
+        assert ns.kept_value(h)
+        assert ns.kept_value(ns.make_handle())


### PR DESCRIPTION
A `const void*` constructor declared before a converting one used to win, so the argument arrived as the proxy's address rather than the converted value.

Fix: compiler-research/CPyCppyy#225
Context: compiler-research/CppInterOp#1078